### PR TITLE
Add indices from names to element IDs

### DIFF
--- a/src/ah/README.md
+++ b/src/ah/README.md
@@ -73,7 +73,9 @@ Replace `/absolute/path/to/ah.env` with the actual path to your `.env` file. You
 | Tool | Description |
 |---|---|
 | `get_my_organizations` | List all AuditHub organizations the authenticated user belongs to |
+| `get_organization_name_index` | List allowlisted organizations as deterministic name-to-ID lookup entries |
 | `get_project` | Get details for a specific project |
+| `get_project_name_index` | List allowlisted projects in an organization as deterministic name-to-ID lookup entries |
 | `get_latest_version` | Get the latest version of a project |
 | `get_task_info` | Get status and details for an AuditHub task |
 | `get_task_logs` | Get logs for a specific step of a task |
@@ -84,6 +86,10 @@ Replace `/absolute/path/to/ah.env` with the actual path to your `.env` file. You
 | `get_project_comments` | Get all comments for a project across all versions |
 
 All tools return typed Python objects backed by `audithub-sdk` models. On error, tools raise `RuntimeError` with a sanitized plain-text message; the MCP protocol surfaces this as an error response to the caller.
+
+The name index tools only expose organizations and projects that already pass the configured
+allowlists. They are intended to help callers resolve stable human-readable names to internal
+AuditHub IDs before invoking the existing ID-based tools.
 
 ## Security model
 

--- a/src/ah/README.md
+++ b/src/ah/README.md
@@ -80,8 +80,10 @@ Replace `/absolute/path/to/ah.env` with the actual path to your `.env` file. You
 | `get_version_name_index` | List project versions as deterministic name-to-ID lookup entries |
 | `get_task_info` | Get status and details for an AuditHub task |
 | `get_task_logs` | Get logs for a specific step of a task |
+| `get_task_findings` | Get findings produced by a task execution |
 | `get_version_comments` | Get comments for a specific project version |
 | `get_version_comment_threads` | Get comment threads for a specific project version |
+| `get_thread_comments` | Get comments for a specific thread within a project version |
 | `get_project_issues` | Get all issues for a project |
 | `get_project_issue` | Get a specific issue from a project |
 | `get_project_comments` | Get all comments for a project across all versions |

--- a/src/ah/README.md
+++ b/src/ah/README.md
@@ -77,6 +77,7 @@ Replace `/absolute/path/to/ah.env` with the actual path to your `.env` file. You
 | `get_project` | Get details for a specific project |
 | `get_project_name_index` | List allowlisted projects in an organization as deterministic name-to-ID lookup entries |
 | `get_latest_version` | Get the latest version of a project |
+| `get_version_name_index` | List project versions as deterministic name-to-ID lookup entries |
 | `get_task_info` | Get status and details for an AuditHub task |
 | `get_task_logs` | Get logs for a specific step of a task |
 | `get_version_comments` | Get comments for a specific project version |
@@ -88,8 +89,9 @@ Replace `/absolute/path/to/ah.env` with the actual path to your `.env` file. You
 All tools return typed Python objects backed by `audithub-sdk` models. On error, tools raise `RuntimeError` with a sanitized plain-text message; the MCP protocol surfaces this as an error response to the caller.
 
 The name index tools only expose organizations and projects that already pass the configured
-allowlists. They are intended to help callers resolve stable human-readable names to internal
-AuditHub IDs before invoking the existing ID-based tools.
+allowlists. Version name lookup requires an allowlisted organization and project. These tools help
+callers resolve stable human-readable names to internal AuditHub IDs before invoking the existing
+ID-based tools.
 
 ## Security model
 

--- a/src/ah/pyproject.toml
+++ b/src/ah/pyproject.toml
@@ -5,7 +5,7 @@ description = "Read-only MCP server for AuditHub"
 requires-python = ">=3.12"
 dependencies = [
     "mcp>=1.0.0",
-    "audithub-sdk @ git+https://github.com/Veridise/audithub-sdk.git",
+    "audithub-sdk>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/ah/src/ah_mcp/models.py
+++ b/src/ah/src/ah_mcp/models.py
@@ -1,6 +1,7 @@
 """SDK-backed AuditHub models and MCP-specific response types."""
 
 from audithub_sdk.models.comment import Comment
+from audithub_sdk.models.fio_data import FIOData
 from audithub_sdk.models.issue_details import IssueDetails
 from audithub_sdk.models.issue_for_list import IssueForList
 from audithub_sdk.models.organization import Organization
@@ -42,6 +43,7 @@ class VersionNameIndexEntry(BaseModel):
 
 __all__ = [
     "Comment",
+    "FIOData",
     "IssueDetails",
     "IssueForList",
     "Organization",

--- a/src/ah/src/ah_mcp/models.py
+++ b/src/ah/src/ah_mcp/models.py
@@ -1,4 +1,4 @@
-"""SDK-backed AuditHub models re-exported for MCP tool typing."""
+"""SDK-backed AuditHub models and MCP-specific response types."""
 
 from audithub_sdk.models.comment import Comment
 from audithub_sdk.models.issue_details import IssueDetails
@@ -8,13 +8,36 @@ from audithub_sdk.models.project import Project
 from audithub_sdk.models.task import Task
 from audithub_sdk.models.thread import Thread
 from audithub_sdk.models.version import Version
+from pydantic import BaseModel, ConfigDict
+
+
+class OrganizationNameIndexEntry(BaseModel):
+    """Name lookup entry for an allowlisted AuditHub organization."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: int
+    name: str
+    lookup_key: str
+
+
+class ProjectNameIndexEntry(BaseModel):
+    """Name lookup entry for an allowlisted AuditHub project."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: int
+    name: str
+    lookup_key: str
 
 __all__ = [
     "Comment",
     "IssueDetails",
     "IssueForList",
     "Organization",
+    "OrganizationNameIndexEntry",
     "Project",
+    "ProjectNameIndexEntry",
     "Task",
     "Thread",
     "Version",

--- a/src/ah/src/ah_mcp/models.py
+++ b/src/ah/src/ah_mcp/models.py
@@ -30,6 +30,16 @@ class ProjectNameIndexEntry(BaseModel):
     name: str
     lookup_key: str
 
+
+class VersionNameIndexEntry(BaseModel):
+    """Name lookup entry for an allowlisted AuditHub version."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: int
+    name: str
+    lookup_key: str
+
 __all__ = [
     "Comment",
     "IssueDetails",
@@ -41,4 +51,5 @@ __all__ = [
     "Task",
     "Thread",
     "Version",
+    "VersionNameIndexEntry",
 ]

--- a/src/ah/src/ah_mcp/server.py
+++ b/src/ah/src/ah_mcp/server.py
@@ -40,6 +40,7 @@ from ah_mcp.models import (
     Task,
     Thread,
     Version,
+    VersionNameIndexEntry,
 )
 
 _AhId = Annotated[int, Field(strict=True, gt=0)]
@@ -71,6 +72,7 @@ _comment_ta = TypeAdapter(list[Comment])
 _thread_ta = TypeAdapter(list[Thread])
 _issue_list_ta = TypeAdapter(list[IssueForList])
 _project_ta = TypeAdapter(list[Project])
+_version_ta = TypeAdapter(list[Version])
 _str_list_ta = TypeAdapter(list[str])
 
 
@@ -316,6 +318,38 @@ async def get_latest_version(organization_id: _AhId, project_id: _AhId) -> Versi
     return await _run_tool(
         _run,
         tool_name="get_latest_version",
+        safe_args={"organization_id": organization_id, "project_id": project_id},
+    )
+
+
+@mcp.tool()
+async def get_version_name_index(
+    organization_id: _AhId, project_id: _AhId
+) -> list[VersionNameIndexEntry]:
+    """List project versions as deterministic name lookup entries."""
+
+    async def _run() -> list[VersionNameIndexEntry]:
+        _assert_org_allowed(organization_id)
+        _assert_project_allowed(project_id)
+        versions = await _with_api_client(
+            lambda client: VersionsApi(client).get_versions_organizations_organization_id_projects_project_id_versions_get(  # noqa: E501
+                organization_id=organization_id,
+                project_id=project_id,
+            )
+        )
+        entries = [
+            VersionNameIndexEntry(
+                id=version.id,
+                name=version.name,
+                lookup_key=_normalize_lookup_key(version.name),
+            )
+            for version in _version_ta.validate_python(versions)
+        ]
+        return sorted(entries, key=lambda entry: (entry.lookup_key, entry.id))
+
+    return await _run_tool(
+        _run,
+        tool_name="get_version_name_index",
         safe_args={"organization_id": organization_id, "project_id": project_id},
     )
 

--- a/src/ah/src/ah_mcp/server.py
+++ b/src/ah/src/ah_mcp/server.py
@@ -277,20 +277,32 @@ async def get_project_name_index(organization_id: _AhId) -> list[ProjectNameInde
 
     async def _run() -> list[ProjectNameIndexEntry]:
         _assert_org_allowed(organization_id)
-        projects = await _with_api_client(
-            lambda client: ProjectsApi(client).get_projects_organizations_organization_id_projects_get(  # noqa: E501
-                organization_id=organization_id
+
+        async def _fetch_project(project_id: int) -> Project:
+            project = await _with_api_client(
+                lambda client: ProjectsApi(client).get_project_organizations_organization_id_projects_project_id_get(  # noqa: E501
+                    organization_id=organization_id,
+                    project_id=project_id,
+                )
             )
-        )
-        entries = [
-            ProjectNameIndexEntry(
-                id=project.id,
-                name=project.name,
-                lookup_key=_normalize_lookup_key(project.name),
+            return Project.model_validate(project)
+
+        entries: list[ProjectNameIndexEntry] = []
+        for project_id in sorted(_allowed_project_ids):
+            try:
+                validated_project = await _fetch_project(project_id)
+            except Exception as exc:
+                status = getattr(exc, "status", None)
+                if isinstance(status, int) and status == 404:
+                    continue
+                raise
+            entries.append(
+                ProjectNameIndexEntry(
+                    id=validated_project.id,
+                    name=validated_project.name,
+                    lookup_key=_normalize_lookup_key(validated_project.name),
+                )
             )
-            for project in _project_ta.validate_python(projects)
-            if project.id in _allowed_project_ids
-        ]
         return sorted(entries, key=lambda entry: (entry.lookup_key, entry.id))
 
     return await _run_tool(

--- a/src/ah/src/ah_mcp/server.py
+++ b/src/ah/src/ah_mcp/server.py
@@ -34,7 +34,9 @@ from ah_mcp.models import (
     IssueDetails,
     IssueForList,
     Organization,
+    OrganizationNameIndexEntry,
     Project,
+    ProjectNameIndexEntry,
     Task,
     Thread,
     Version,
@@ -68,6 +70,7 @@ _org_ta = TypeAdapter(list[Organization])
 _comment_ta = TypeAdapter(list[Comment])
 _thread_ta = TypeAdapter(list[Thread])
 _issue_list_ta = TypeAdapter(list[IssueForList])
+_project_ta = TypeAdapter(list[Project])
 _str_list_ta = TypeAdapter(list[str])
 
 
@@ -149,6 +152,11 @@ def _slice_paginated[T](items: Sequence[T], limit: int | None, offset: int | Non
     return list(items[start:end])
 
 
+def _normalize_lookup_key(name: str) -> str:
+    """Normalize a user-visible name into a deterministic case-insensitive lookup key."""
+    return name.strip().casefold()
+
+
 async def _with_api_client[T](fn: Callable[[AuthenticatedApiClient], Awaitable[T]]) -> T:
     """Create an authenticated SDK client for a single tool invocation."""
     ctx = _ctx()
@@ -217,6 +225,29 @@ async def get_my_organizations() -> list[Organization]:
 
 
 @mcp.tool()
+async def get_organization_name_index() -> list[OrganizationNameIndexEntry]:
+    """List allowlisted AuditHub organizations as deterministic name lookup entries."""
+
+    async def _run() -> list[OrganizationNameIndexEntry]:
+        organizations = await _with_api_client(
+            lambda client: UsersApi(client).get_organizations_users_myorganizations_get()
+        )
+        orgs = _org_ta.validate_python(organizations)
+        entries = [
+            OrganizationNameIndexEntry(
+                id=org.id,
+                name=org.name,
+                lookup_key=_normalize_lookup_key(org.name),
+            )
+            for org in orgs
+            if org.id in _allowed_org_ids
+        ]
+        return sorted(entries, key=lambda entry: (entry.lookup_key, entry.id))
+
+    return await _run_tool(_run, tool_name="get_organization_name_index", safe_args={})
+
+
+@mcp.tool()
 async def get_project(organization_id: _AhId, project_id: _AhId) -> Project:
     """Get details for a specific AuditHub project."""
 
@@ -235,6 +266,35 @@ async def get_project(organization_id: _AhId, project_id: _AhId) -> Project:
         _run,
         tool_name="get_project",
         safe_args={"organization_id": organization_id, "project_id": project_id},
+    )
+
+
+@mcp.tool()
+async def get_project_name_index(organization_id: _AhId) -> list[ProjectNameIndexEntry]:
+    """List allowlisted projects in an organization as deterministic name lookup entries."""
+
+    async def _run() -> list[ProjectNameIndexEntry]:
+        _assert_org_allowed(organization_id)
+        projects = await _with_api_client(
+            lambda client: ProjectsApi(client).get_projects_organizations_organization_id_projects_get(  # noqa: E501
+                organization_id=organization_id
+            )
+        )
+        entries = [
+            ProjectNameIndexEntry(
+                id=project.id,
+                name=project.name,
+                lookup_key=_normalize_lookup_key(project.name),
+            )
+            for project in _project_ta.validate_python(projects)
+            if project.id in _allowed_project_ids
+        ]
+        return sorted(entries, key=lambda entry: (entry.lookup_key, entry.id))
+
+    return await _run_tool(
+        _run,
+        tool_name="get_project_name_index",
+        safe_args={"organization_id": organization_id},
     )
 
 

--- a/src/ah/src/ah_mcp/server.py
+++ b/src/ah/src/ah_mcp/server.py
@@ -31,6 +31,7 @@ from pydantic import Field, TypeAdapter
 from ah_mcp.audit import log_call_error, log_call_start, log_call_success
 from ah_mcp.models import (
     Comment,
+    FIOData,
     IssueDetails,
     IssueForList,
     Organization,
@@ -69,6 +70,7 @@ _allowed_project_ids: frozenset[int] = frozenset()
 
 _org_ta = TypeAdapter(list[Organization])
 _comment_ta = TypeAdapter(list[Comment])
+_fio_data_ta = TypeAdapter(list[FIOData])
 _thread_ta = TypeAdapter(list[Thread])
 _issue_list_ta = TypeAdapter(list[IssueForList])
 _project_ta = TypeAdapter(list[Project])
@@ -410,6 +412,27 @@ async def get_task_logs(organization_id: _AhId, task_id: _AhId, step_code: str) 
 
 
 @mcp.tool()
+async def get_task_findings(organization_id: _AhId, task_id: _AhId) -> list[FIOData]:
+    """Get findings produced by an AuditHub task execution."""
+
+    async def _run() -> list[FIOData]:
+        _assert_org_allowed(organization_id)
+        findings = await _with_api_client(
+            lambda client: TasksApi(client).get_task_findings_organizations_organization_id_tasks_task_id_findings_get(  # noqa: E501
+                organization_id=organization_id,
+                task_id=task_id,
+            )
+        )
+        return _fio_data_ta.validate_python(findings)
+
+    return await _run_tool(
+        _run,
+        tool_name="get_task_findings",
+        safe_args={"organization_id": organization_id, "task_id": task_id},
+    )
+
+
+@mcp.tool()
 async def get_version_comments(
     organization_id: _AhId,
     project_id: _AhId,
@@ -417,7 +440,11 @@ async def get_version_comments(
     limit: Annotated[int, Field(ge=0)] | None = 200,
     offset: Annotated[int, Field(ge=0)] | None = 0,
 ) -> list[Comment]:
-    """Get comments for a specific project version."""
+    """Get comments for a specific project version. Use this only to aggregate comments 
+       at the version level, if you are looking for a specific thread id use 
+       get_thread_comments instead.
+
+       This can return large objects, prefer pagination to avoid truncation by MCP."""
 
     async def _run() -> list[Comment]:
         _build_pagination_params(limit, offset)
@@ -477,6 +504,48 @@ async def get_version_comment_threads(
             "organization_id": organization_id,
             "project_id": project_id,
             "version_id": version_id,
+            "limit": limit,
+            "offset": offset,
+        },
+    )
+
+
+@mcp.tool()
+async def get_thread_comments(
+    organization_id: _AhId,
+    project_id: _AhId,
+    version_id: _AhId,
+    thread_id: _AhId,
+    limit: Annotated[int, Field(ge=0)] | None = 200,
+    offset: Annotated[int, Field(ge=0)] | None = 0,
+) -> list[Comment]:
+    """Get comments for a specific thread within a project version.
+       This can return large objects, prefer pagination to avoid truncation by MCP."""
+
+    async def _run() -> list[Comment]:
+        _build_pagination_params(limit, offset)
+        _assert_org_allowed(organization_id)
+        _assert_project_allowed(project_id)
+        comments = await _with_api_client(
+            lambda client: VersionsApi(client).get_version_comments_organizations_organization_id_projects_project_id_versions_version_id_comments_get(  # noqa: E501
+                organization_id=organization_id,
+                project_id=project_id,
+                version_id=version_id,
+                thread_id=thread_id,
+                limit=limit,
+                offset=offset,
+            )
+        )
+        return _comment_ta.validate_python(comments)
+
+    return await _run_tool(
+        _run,
+        tool_name="get_thread_comments",
+        safe_args={
+            "organization_id": organization_id,
+            "project_id": project_id,
+            "version_id": version_id,
+            "thread_id": thread_id,
             "limit": limit,
             "offset": offset,
         },
@@ -552,7 +621,11 @@ async def get_project_comments(
     limit: Annotated[int, Field(ge=0)] | None = 200,
     offset: Annotated[int, Field(ge=0)] | None = 0,
 ) -> list[Comment]:
-    """Get all comments for an AuditHub project across all versions."""
+    """Get all comments for an AuditHub project across all versions. Use this only to
+       aggregate comments at the project level, if you are looking for a specific thread
+       id use get_thread_comments instead.
+       
+       This can return large objects, prefer pagination to avoid truncation by MCP."""
 
     async def _run() -> list[Comment]:
         _build_pagination_params(limit, offset)

--- a/src/ah/tests/sdk_stubs.py
+++ b/src/ah/tests/sdk_stubs.py
@@ -152,6 +152,11 @@ class ProjectsApi(_ApiBase):
 
 
 class VersionsApi(_ApiBase):
+    async def get_versions_organizations_organization_id_projects_project_id_versions_get(
+        self, **kwargs
+    ):
+        raise NotImplementedError
+
     async def get_latest_version_organizations_organization_id_projects_project_id_versions_latest_get(  # noqa: E501
         self, **kwargs
     ):

--- a/src/ah/tests/sdk_stubs.py
+++ b/src/ah/tests/sdk_stubs.py
@@ -52,6 +52,14 @@ class Task(_BaseSdkModel):
     created_at: datetime
 
 
+class FIOData(_BaseSdkModel):
+    state_digest: int
+    analysis_result_id: str
+    is_filtered: bool
+    data: dict[str, Any] | None = None
+    actions: list[dict[str, Any]] | None = None
+
+
 class Comment(_BaseSdkModel):
     project_id: int
     version_id: int | None = None
@@ -163,7 +171,14 @@ class VersionsApi(_ApiBase):
         raise NotImplementedError
 
     async def get_version_comments_organizations_organization_id_projects_project_id_versions_version_id_comments_get(  # noqa: E501
-        self, **kwargs
+        self,
+        *,
+        organization_id: int,
+        project_id: int,
+        version_id: int,
+        limit: int | None = None,
+        offset: int | None = None,
+        thread_id: int | None = None,
     ):
         raise NotImplementedError
 
@@ -187,6 +202,11 @@ class IssuesApi(_ApiBase):
 
 class TasksApi(_ApiBase):
     async def get_info_organizations_organization_id_tasks_task_id_get(self, **kwargs):
+        raise NotImplementedError
+
+    async def get_task_findings_organizations_organization_id_tasks_task_id_findings_get(
+        self, **kwargs
+    ):
         raise NotImplementedError
 
     async def get_output_organizations_organization_id_tasks_task_id_step_code_output_get(
@@ -224,6 +244,7 @@ def install_sdk_stubs() -> None:
         ("project", Project),
         ("version", Version),
         ("task", Task),
+        ("fio_data", FIOData),
         ("comment", Comment),
         ("thread", Thread),
         ("issue_for_list", IssueForList),

--- a/src/ah/tests/sdk_stubs.py
+++ b/src/ah/tests/sdk_stubs.py
@@ -139,6 +139,9 @@ class UsersApi(_ApiBase):
 
 
 class ProjectsApi(_ApiBase):
+    async def get_projects_organizations_organization_id_projects_get(self, **kwargs):
+        raise NotImplementedError
+
     async def get_project_organizations_organization_id_projects_project_id_get(self, **kwargs):
         raise NotImplementedError
 

--- a/src/ah/tests/test_integration.py
+++ b/src/ah/tests/test_integration.py
@@ -25,6 +25,7 @@ from ah_mcp.models import (  # noqa: E402
     Project,
     Thread,
     Version,
+    VersionNameIndexEntry,
 )
 
 pytestmark = pytest.mark.integration
@@ -65,6 +66,12 @@ def test_get_latest_version() -> None:
     version = _run(server.get_latest_version(organization_id=_ORG_ID, project_id=_PROJECT_ID))
     assert isinstance(version, Version)
     assert version.id > 0
+
+
+def test_list_version_name_index() -> None:
+    entries = _run(server.get_version_name_index(organization_id=_ORG_ID, project_id=_PROJECT_ID))
+    assert isinstance(entries, list)
+    assert all(isinstance(entry, VersionNameIndexEntry) for entry in entries)
 
 
 def test_list_issues() -> None:

--- a/src/ah/tests/test_integration.py
+++ b/src/ah/tests/test_integration.py
@@ -117,3 +117,27 @@ def test_list_version_threads() -> None:
     )
     assert isinstance(threads, list)
     assert all(isinstance(thread, Thread) for thread in threads)
+
+
+def test_get_thread_comments_if_thread_present() -> None:
+    version = _run(server.get_latest_version(organization_id=_ORG_ID, project_id=_PROJECT_ID))
+    threads = _run(
+        server.get_version_comment_threads(
+            organization_id=_ORG_ID, project_id=_PROJECT_ID, version_id=version.id, limit=10
+        )
+    )
+    if not threads:
+        pytest.skip("No threads found in version — cannot test get_thread_comments")
+
+    comments = _run(
+        server.get_thread_comments(
+            organization_id=_ORG_ID,
+            project_id=_PROJECT_ID,
+            version_id=version.id,
+            thread_id=threads[0].id,
+            limit=10,
+        )
+    )
+    assert isinstance(comments, list)
+    assert all(isinstance(comment, Comment) for comment in comments)
+    assert all(comment.thread_id == threads[0].id for comment in comments)

--- a/src/ah/tests/test_security.py
+++ b/src/ah/tests/test_security.py
@@ -52,7 +52,7 @@ class TestDisallowedIds(unittest.IsolatedAsyncioTestCase):
         mock = AsyncMock(return_value=[{"id": 10, "name": "Audit"}])
         with patch.object(
             server.ProjectsApi,
-            "get_projects_organizations_organization_id_projects_get",
+            "get_project_organizations_organization_id_projects_project_id_get",
             mock,
         ), self.assertRaises(RuntimeError):
             await server.get_project_name_index(organization_id=999)

--- a/src/ah/tests/test_security.py
+++ b/src/ah/tests/test_security.py
@@ -42,6 +42,22 @@ class TestDisallowedIds(unittest.IsolatedAsyncioTestCase):
             await server.get_project(organization_id=999, project_id=10)
         mock.assert_not_awaited()
 
+    async def test_task_findings_disallowed_org(self) -> None:
+        with self.assertRaises(RuntimeError) as cm:
+            await server.get_task_findings(organization_id=999, task_id=10)
+        self.assertIn("999", str(cm.exception))
+        self.assertNotIn("frozenset", str(cm.exception))
+
+    async def test_task_findings_rejected_call_does_not_reach_sdk(self) -> None:
+        mock = AsyncMock(return_value=[])
+        with patch.object(
+            server.TasksApi,
+            "get_task_findings_organizations_organization_id_tasks_task_id_findings_get",
+            mock,
+        ), self.assertRaises(RuntimeError):
+            await server.get_task_findings(organization_id=999, task_id=10)
+        mock.assert_not_awaited()
+
     async def test_project_name_index_disallowed_org(self) -> None:
         with self.assertRaises(RuntimeError) as cm:
             await server.get_project_name_index(organization_id=999)

--- a/src/ah/tests/test_security.py
+++ b/src/ah/tests/test_security.py
@@ -58,6 +58,28 @@ class TestDisallowedIds(unittest.IsolatedAsyncioTestCase):
             await server.get_project_name_index(organization_id=999)
         mock.assert_not_awaited()
 
+    async def test_version_name_index_disallowed_org(self) -> None:
+        with self.assertRaises(RuntimeError) as cm:
+            await server.get_version_name_index(organization_id=999, project_id=10)
+        self.assertIn("999", str(cm.exception))
+        self.assertNotIn("frozenset", str(cm.exception))
+
+    async def test_version_name_index_disallowed_project(self) -> None:
+        with self.assertRaises(RuntimeError) as cm:
+            await server.get_version_name_index(organization_id=1, project_id=999)
+        self.assertIn("999", str(cm.exception))
+        self.assertNotIn("frozenset", str(cm.exception))
+
+    async def test_version_name_index_rejected_call_does_not_reach_sdk(self) -> None:
+        mock = AsyncMock(return_value=[{"id": 42, "name": "v1.0"}])
+        with patch.object(
+            server.VersionsApi,
+            "get_versions_organizations_organization_id_projects_project_id_versions_get",
+            mock,
+        ), self.assertRaises(RuntimeError):
+            await server.get_version_name_index(organization_id=999, project_id=10)
+        mock.assert_not_awaited()
+
 
 class TestStepCodePrivacy(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:

--- a/src/ah/tests/test_security.py
+++ b/src/ah/tests/test_security.py
@@ -42,6 +42,22 @@ class TestDisallowedIds(unittest.IsolatedAsyncioTestCase):
             await server.get_project(organization_id=999, project_id=10)
         mock.assert_not_awaited()
 
+    async def test_project_name_index_disallowed_org(self) -> None:
+        with self.assertRaises(RuntimeError) as cm:
+            await server.get_project_name_index(organization_id=999)
+        self.assertIn("999", str(cm.exception))
+        self.assertNotIn("frozenset", str(cm.exception))
+
+    async def test_project_name_index_rejected_call_does_not_reach_sdk(self) -> None:
+        mock = AsyncMock(return_value=[{"id": 10, "name": "Audit"}])
+        with patch.object(
+            server.ProjectsApi,
+            "get_projects_organizations_organization_id_projects_get",
+            mock,
+        ), self.assertRaises(RuntimeError):
+            await server.get_project_name_index(organization_id=999)
+        mock.assert_not_awaited()
+
 
 class TestStepCodePrivacy(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:

--- a/src/ah/tests/test_server.py
+++ b/src/ah/tests/test_server.py
@@ -282,16 +282,38 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.id, 10)
 
     async def test_get_project_name_index_filters_and_sorts(self) -> None:
+        mock = AsyncMock(side_effect=[_PROJECT_DICT_TWO, _PROJECT_DICT])
         with patch.object(
             server.ProjectsApi,
-            "get_projects_organizations_organization_id_projects_get",
-            AsyncMock(return_value=[_PROJECT_DICT_TWO, _PROJECT_DICT, _PROJECT_DICT_THREE]),
+            "get_project_organizations_organization_id_projects_project_id_get",
+            mock,
         ):
             server._allowed_project_ids = frozenset({10, 20})
             result = await server.get_project_name_index(organization_id=1)
         self.assertEqual([item.id for item in result], [10, 20])
         self.assertEqual([item.lookup_key for item in result], ["audit", "zebra"])
         self.assertTrue(all(isinstance(item, ProjectNameIndexEntry) for item in result))
+        self.assertEqual(
+            [call.kwargs for call in mock.await_args_list],
+            [
+                {"organization_id": 1, "project_id": 10},
+                {"organization_id": 1, "project_id": 20},
+            ],
+        )
+
+    async def test_get_project_name_index_skips_404_projects(self) -> None:
+        class _NotFoundError(Exception):
+            status = 404
+
+        mock = AsyncMock(side_effect=[_PROJECT_DICT, _NotFoundError()])
+        with patch.object(
+            server.ProjectsApi,
+            "get_project_organizations_organization_id_projects_project_id_get",
+            mock,
+        ):
+            server._allowed_project_ids = frozenset({10, 20})
+            result = await server.get_project_name_index(organization_id=1)
+        self.assertEqual([item.id for item in result], [10])
 
     async def test_get_latest_version_returns_version(self) -> None:
         with patch.object(
@@ -419,7 +441,7 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
         mock = AsyncMock(return_value=[_PROJECT_DICT])
         with patch.object(
             server.ProjectsApi,
-            "get_projects_organizations_organization_id_projects_get",
+            "get_project_organizations_organization_id_projects_project_id_get",
             mock,
         ), self.assertRaises(RuntimeError):
             await server.get_project_name_index(organization_id=99)

--- a/src/ah/tests/test_server.py
+++ b/src/ah/tests/test_server.py
@@ -16,7 +16,9 @@ from ah_mcp.models import (  # noqa: E402
     IssueDetails,
     IssueForList,
     Organization,
+    OrganizationNameIndexEntry,
     Project,
+    ProjectNameIndexEntry,
     Task,
     Thread,
     Version,
@@ -40,6 +42,16 @@ _PROJECT_DICT = {
     "created_at": _TIMESTAMP,
     "gh_repo": "acme/audit",
     "is_deployed": False,
+}
+_PROJECT_DICT_TWO = {
+    **_PROJECT_DICT,
+    "id": 20,
+    "name": " Zebra ",
+}
+_PROJECT_DICT_THREE = {
+    **_PROJECT_DICT,
+    "id": 30,
+    "name": "Ignored",
 }
 _VERSION_DICT = {
     "id": 42,
@@ -230,6 +242,24 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([org.id for org in result], [1])
         self.assertIsInstance(result[0], Organization)
 
+    async def test_get_organization_name_index_filters_and_sorts(self) -> None:
+        with patch.object(
+            server.UsersApi,
+            "get_organizations_users_myorganizations_get",
+            AsyncMock(
+                return_value=[
+                    {**_ORG_DICT, "id": 1, "name": " Zebra "},
+                    {**_ORG_DICT, "id": 2, "name": "alpha"},
+                    {**_ORG_DICT, "id": 99, "name": "Other"},
+                ]
+            ),
+        ):
+            server._allowed_org_ids = frozenset({1, 2})
+            result = await server.get_organization_name_index()
+        self.assertEqual([item.id for item in result], [2, 1])
+        self.assertEqual([item.lookup_key for item in result], ["alpha", "zebra"])
+        self.assertTrue(all(isinstance(item, OrganizationNameIndexEntry) for item in result))
+
     async def test_get_project_returns_project(self) -> None:
         with patch.object(
             server.ProjectsApi,
@@ -239,6 +269,18 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             result = await server.get_project(organization_id=1, project_id=10)
         self.assertIsInstance(result, Project)
         self.assertEqual(result.id, 10)
+
+    async def test_get_project_name_index_filters_and_sorts(self) -> None:
+        with patch.object(
+            server.ProjectsApi,
+            "get_projects_organizations_organization_id_projects_get",
+            AsyncMock(return_value=[_PROJECT_DICT_TWO, _PROJECT_DICT, _PROJECT_DICT_THREE]),
+        ):
+            server._allowed_project_ids = frozenset({10, 20})
+            result = await server.get_project_name_index(organization_id=1)
+        self.assertEqual([item.id for item in result], [10, 20])
+        self.assertEqual([item.lookup_key for item in result], ["audit", "zebra"])
+        self.assertTrue(all(isinstance(item, ProjectNameIndexEntry) for item in result))
 
     async def test_get_latest_version_returns_version(self) -> None:
         with patch.object(
@@ -348,6 +390,16 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             await server.get_project_issues(organization_id=99, project_id=10)
         mock.assert_not_awaited()
 
+    async def test_get_project_name_index_rejection_prevents_sdk_call(self) -> None:
+        mock = AsyncMock(return_value=[_PROJECT_DICT])
+        with patch.object(
+            server.ProjectsApi,
+            "get_projects_organizations_organization_id_projects_get",
+            mock,
+        ), self.assertRaises(RuntimeError):
+            await server.get_project_name_index(organization_id=99)
+        mock.assert_not_awaited()
+
     async def test_non_runtime_error_is_sanitized(self) -> None:
         with patch.object(
             server.UsersApi,
@@ -356,6 +408,9 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
         ), self.assertRaises(RuntimeError) as cm:
             await server.get_my_organizations()
         self.assertNotIn("network secret", str(cm.exception))
+
+    def test_normalize_lookup_key(self) -> None:
+        self.assertEqual(server._normalize_lookup_key("  AcMe DAO  "), "acme dao")
 
 
 class TestFastMCPSchemaValidation(unittest.IsolatedAsyncioTestCase):

--- a/src/ah/tests/test_server.py
+++ b/src/ah/tests/test_server.py
@@ -22,6 +22,7 @@ from ah_mcp.models import (  # noqa: E402
     Task,
     Thread,
     Version,
+    VersionNameIndexEntry,
 )
 
 _TIMESTAMP = "2026-03-26T12:00:00Z"
@@ -62,6 +63,16 @@ _VERSION_DICT = {
     "digest": "digest-42",
     "commit_hash": "abc123",
     "is_deployed": False,
+}
+_VERSION_DICT_TWO = {
+    **_VERSION_DICT,
+    "id": 43,
+    "name": " Release Candidate ",
+}
+_VERSION_DICT_THREE = {
+    **_VERSION_DICT,
+    "id": 44,
+    "name": "alpha",
 }
 _TASK_DICT = {
     "id": 99,
@@ -291,6 +302,20 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             result = await server.get_latest_version(organization_id=1, project_id=10)
         self.assertIsInstance(result, Version)
 
+    async def test_get_version_name_index_filters_and_sorts(self) -> None:
+        with patch.object(
+            server.VersionsApi,
+            "get_versions_organizations_organization_id_projects_project_id_versions_get",
+            AsyncMock(return_value=[_VERSION_DICT_TWO, _VERSION_DICT, _VERSION_DICT_THREE]),
+        ):
+            result = await server.get_version_name_index(organization_id=1, project_id=10)
+        self.assertEqual([item.id for item in result], [44, 43, 42])
+        self.assertEqual(
+            [item.lookup_key for item in result],
+            ["alpha", "release candidate", "v1.0"],
+        )
+        self.assertTrue(all(isinstance(item, VersionNameIndexEntry) for item in result))
+
     async def test_get_task_info_returns_task(self) -> None:
         with patch.object(
             server.TasksApi,
@@ -398,6 +423,16 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             mock,
         ), self.assertRaises(RuntimeError):
             await server.get_project_name_index(organization_id=99)
+        mock.assert_not_awaited()
+
+    async def test_get_version_name_index_rejection_prevents_sdk_call(self) -> None:
+        mock = AsyncMock(return_value=[_VERSION_DICT])
+        with patch.object(
+            server.VersionsApi,
+            "get_versions_organizations_organization_id_projects_project_id_versions_get",
+            mock,
+        ), self.assertRaises(RuntimeError):
+            await server.get_version_name_index(organization_id=1, project_id=99)
         mock.assert_not_awaited()
 
     async def test_non_runtime_error_is_sanitized(self) -> None:

--- a/src/ah/tests/test_server.py
+++ b/src/ah/tests/test_server.py
@@ -13,6 +13,7 @@ install_sdk_stubs()
 import ah_mcp.server as server  # noqa: E402
 from ah_mcp.models import (  # noqa: E402
     Comment,
+    FIOData,
     IssueDetails,
     IssueForList,
     Organization,
@@ -81,6 +82,13 @@ _TASK_DICT = {
     "version_id": 42,
     "status": "Finished",
     "created_at": _TIMESTAMP,
+}
+_FINDING_DICT = {
+    "state_digest": 123,
+    "analysis_result_id": "analysis-1",
+    "is_filtered": False,
+    "data": {"title": "Unchecked call return value"},
+    "actions": [],
 }
 _COMMENT_DICT = {
     "id": 5,
@@ -356,6 +364,16 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             result = await server.get_task_logs(organization_id=1, task_id=99, step_code="analysis")
         self.assertEqual(result, ["a", "b"])
 
+    async def test_get_task_findings_returns_list(self) -> None:
+        with patch.object(
+            server.TasksApi,
+            "get_task_findings_organizations_organization_id_tasks_task_id_findings_get",
+            AsyncMock(return_value=[_FINDING_DICT]),
+        ):
+            result = await server.get_task_findings(organization_id=1, task_id=99)
+        self.assertEqual(result[0].analysis_result_id, "analysis-1")
+        self.assertIsInstance(result[0], FIOData)
+
     async def test_get_version_comments_forwards_limit_offset(self) -> None:
         mock = AsyncMock(return_value=[_COMMENT_DICT])
         with patch.object(
@@ -367,6 +385,27 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
                 organization_id=1, project_id=10, version_id=3, limit=75, offset=25
             )
         kwargs = mock.await_args.kwargs
+        self.assertEqual(kwargs["limit"], 75)
+        self.assertEqual(kwargs["offset"], 25)
+        self.assertIsInstance(result[0], Comment)
+
+    async def test_get_thread_comments_forwards_thread_limit_offset(self) -> None:
+        mock = AsyncMock(return_value=[_COMMENT_DICT])
+        with patch.object(
+            server.VersionsApi,
+            "get_version_comments_organizations_organization_id_projects_project_id_versions_version_id_comments_get",  # noqa: E501
+            mock,
+        ):
+            result = await server.get_thread_comments(
+                organization_id=1,
+                project_id=10,
+                version_id=3,
+                thread_id=7,
+                limit=75,
+                offset=25,
+            )
+        kwargs = mock.await_args.kwargs
+        self.assertEqual(kwargs["thread_id"], 7)
         self.assertEqual(kwargs["limit"], 75)
         self.assertEqual(kwargs["offset"], 25)
         self.assertIsInstance(result[0], Comment)
@@ -457,6 +496,18 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             await server.get_version_name_index(organization_id=1, project_id=99)
         mock.assert_not_awaited()
 
+    async def test_get_thread_comments_rejection_prevents_sdk_call(self) -> None:
+        mock = AsyncMock(return_value=[_COMMENT_DICT])
+        with patch.object(
+            server.VersionsApi,
+            "get_version_comments_organizations_organization_id_projects_project_id_versions_version_id_comments_get",  # noqa: E501
+            mock,
+        ), self.assertRaises(RuntimeError):
+            await server.get_thread_comments(
+                organization_id=99, project_id=10, version_id=3, thread_id=7
+            )
+        mock.assert_not_awaited()
+
     async def test_non_runtime_error_is_sanitized(self) -> None:
         with patch.object(
             server.UsersApi,
@@ -488,6 +539,21 @@ class TestFastMCPSchemaValidation(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises((McpError, Exception)) as cm:
             await server.mcp._tool_manager.call_tool(
                 "get_project", {"organization_id": "1", "project_id": 10}
+            )
+        self.assertIn("validation error", str(cm.exception).lower())
+
+    async def test_string_thread_id_rejected(self) -> None:
+        from mcp.shared.exceptions import McpError
+
+        with self.assertRaises((McpError, Exception)) as cm:
+            await server.mcp._tool_manager.call_tool(
+                "get_thread_comments",
+                {
+                    "organization_id": 1,
+                    "project_id": 10,
+                    "version_id": 42,
+                    "thread_id": "3",
+                },
             )
         self.assertIn("validation error", str(cm.exception).lower())
 


### PR DESCRIPTION
Adds tools so agents can relate org/project/version names to their internal IDs.