### PR TITLE
[NIT] Add missing .env.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ Add to your agent's MCP configuration file (`.codex/config.json` for Codex, `.cl
   "mcpServers": {
     "ah": {
       "command": "bash",
-      "args": ["-c", "set -a && source /absolute/path/to/ah.env && set +a && ah-mcp"]
+      "args": [
+        "-c",
+        "cd /absolute/path/to/mcp-servers && set -a && source /absolute/path/to/ah.env && set +a && uv run ah-mcp"
+      ]
     }
   }
 }

--- a/src/ah/.env.example
+++ b/src/ah/.env.example
@@ -1,0 +1,13 @@
+# AuditHub REST API base URL.
+AUDITHUB_BASE_URL=https://audithub.veridise.com/api/v1
+
+# OpenID Connect discovery document URL for your identity provider.
+AUDITHUB_OIDC_CONFIGURATION_URL=https://example.com/.well-known/openid-configuration
+
+# OIDC client credentials. Replace these before running the server.
+AUDITHUB_OIDC_CLIENT_ID=example-client-id
+AUDITHUB_OIDC_CLIENT_SECRET=example-client-secret
+
+# Comma-separated numeric allowlists for AuditHub resources this server may access.
+AH_ALLOWED_ORG_IDS=1,2,3
+AH_ALLOWED_PROJECT_IDS=10,20

--- a/src/ah/README.md
+++ b/src/ah/README.md
@@ -18,6 +18,12 @@ Read-only MCP server for [AuditHub](https://audithub.veridise.com). Exposes Audi
 uv sync --active
 ```
 
+If your virtual environment is not already activated, run the command through `uv` instead:
+
+```bash
+uv run ah-mcp --help
+```
+
 ## Override `audithub-sdk` Locally
 
 To test `ah-mcp` against a local checkout of `audithub-sdk`, add a path source override in the
@@ -63,7 +69,7 @@ CLI flags `--allowed-org-ids` and `--allowed-project-ids` override the correspon
 Copy `.env.example` to `.env`, fill in your values, then:
 
 ```bash
-set -a && source .env && set +a && ah-mcp
+set -a && source .env && set +a && uv run ah-mcp
 ```
 
 All six variables in `.env` must be set before the server starts. Missing variables cause an immediate exit with a clear error listing which are absent.
@@ -79,13 +85,18 @@ Add to your agent's MCP configuration (e.g. `.codex/config.json` for Codex, `.cl
   "mcpServers": {
     "ah": {
       "command": "bash",
-      "args": ["-c", "set -a && source /absolute/path/to/ah.env && set +a && ah-mcp"]
+      "args": [
+        "-c",
+        "cd /absolute/path/to/mcp-servers && set -a && source /absolute/path/to/ah.env && set +a && uv run ah-mcp"
+      ]
     }
   }
 }
 ```
 
-Replace `/absolute/path/to/ah.env` with the actual path to your `.env` file. Your `.env` file (see `.env.example`) holds all credentials and allowlist IDs; no secrets belong in the agent config file.
+Replace `/absolute/path/to/mcp-servers` with this repository path and `/absolute/path/to/ah.env`
+with the actual path to your `.env` file. Your `.env` file (see `.env.example`) holds all
+credentials and allowlist IDs; no secrets belong in the agent config file.
 
 ## Available MCP tools
 


### PR DESCRIPTION
The README mentions this example but it doesn't actually exist so I'm adding it.

NOTE: The CI failure comes from the updated SDK and is fixed here: https://github.com/Veridise/mcp-servers/pull/17