### PR TITLE
[IMPROVEMENT] Add validation to ensure on-chain orca tasks set values appropriately before submitting to AuditHub

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -40,7 +40,7 @@ jobs:
           uv sync --frozen
 
       - name: Supply chain audit
-        run: uv run pip-audit
+        run: uv run pip-audit --skip-editable
 
       - name: Lint (ruff)
         run: uv run ruff check src tests

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 .mypy_cache/
 .ruff_cache/
 .pytest_cache/
+.uv-cache/
 .coverage
 .env
 dist/

--- a/src/ah/README.md
+++ b/src/ah/README.md
@@ -136,6 +136,7 @@ ID-based tools.
 
 - **Read-only by default.** Default tools are named `get_*` and only invoke generated `audithub-sdk` GET endpoints.
 - **Opt-in OrCa task execution.** The `run_orca_task` mutation tool is registered only when `AH_ENABLE_TASK_RUNS=1` or `--enable-task-runs` is supplied. It calls the generated OrCa POST endpoint through `audithub-sdk`.
+- **On-chain OrCa mode.** When launching OrCa against already deployed contracts, pass `deployment_info_file` as a path ending in `.deployment.json`. The server normalizes that into `on_chain=True` and rejects mismatched paths early so callers do not accidentally launch a local Foundry-style run.
 - **Opt-in version creation.** The `create_version_from_url` mutation tool is registered only when `AH_ENABLE_VERSION_CREATION=1` or `--enable-version-creation` is supplied. It calls the generated project version URL POST endpoint through `audithub-sdk`.
 - **Credential isolation.** OIDC credentials are read from the environment once at startup and passed into `audithub_sdk_ext.AuthenticatedApiClient`. They are never accepted as tool arguments and are not surfaced in tool outputs or sanitized error messages.
 - **ID allowlisting.** The server refuses to access any organization or project whose numeric ID was not explicitly included in `AH_ALLOWED_ORG_IDS` / `AH_ALLOWED_PROJECT_IDS`. The check runs before any network request.

--- a/src/ah/src/ah_mcp/models.py
+++ b/src/ah/src/ah_mcp/models.py
@@ -12,7 +12,7 @@ from audithub_sdk.models.task import Task
 from audithub_sdk.models.task_creation import TaskCreation
 from audithub_sdk.models.thread import Thread
 from audithub_sdk.models.version import Version
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 _PositiveId = Annotated[int, Field(strict=True, gt=0)]
 
@@ -234,12 +234,52 @@ class OrCaTaskInput(BaseModel):
 
     specs_override: Annotated[list[OrCaSpecReference], Field(min_length=1)]
     hints_override: list[OrCaHintReference] | None = None
-    deployment_script_path_override: str | None = None
-    on_chain: bool | None = False
-    deployment_info_file: str | None = None
+    deployment_script_path_override: str | None = Field(
+        default=None,
+        description="Optional deployment script path for source-based OrCa runs.",
+    )
+    on_chain: bool | None = Field(
+        default=False,
+        description=(
+            "Enable on-chain OrCa fuzzing. Prefer setting deployment_info_file to a "
+            "path ending in .deployment.json; the server will normalize that to "
+            "on_chain=True."
+        ),
+    )
+    deployment_info_file: str | None = Field(
+        default=None,
+        description=(
+            "Path to a .deployment.json file containing deployed_contract_information "
+            "for on-chain fuzzing."
+        ),
+    )
     auxiliary_deployment_script: str | None = None
     name: str | None = None
     parameters: OrCaParametersInput = Field(default_factory=OrCaParametersInput)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_on_chain_mode(cls, data: object) -> object:
+        """Normalize and validate the on-chain OrCa task settings."""
+        if not isinstance(data, dict):
+            return data
+        deployment_info_file = data.get("deployment_info_file")
+        on_chain = data.get("on_chain")
+        if deployment_info_file is not None and not deployment_info_file.endswith(
+            ".deployment.json"
+        ):
+            raise ValueError(
+                "deployment_info_file must end with .deployment.json for on-chain fuzzing."
+            )
+        if deployment_info_file is not None and on_chain is not True:
+            normalized = dict(data)
+            normalized["on_chain"] = True
+            return normalized
+        if on_chain is True and deployment_info_file is None:
+            raise ValueError(
+                "on_chain=True requires deployment_info_file to point to a .deployment.json file."
+            )
+        return data
 
 __all__ = [
     "Comment",

--- a/src/ah/tests/test_security.py
+++ b/src/ah/tests/test_security.py
@@ -220,8 +220,8 @@ class TestDisallowedIds(unittest.IsolatedAsyncioTestCase):
         server._set_version_creation_enabled(True)
         mock = AsyncMock(return_value={"id": 1, "message": "created"})
         with patch.object(
-            server.VersionsApi,
-            "post_version_organizations_organization_id_projects_project_id_versions_post",
+            server,
+            "_create_version_from_archive_with_client",
             mock,
         ), self.assertRaises(RuntimeError) as cm:
             await server.create_version_from_archive(
@@ -240,8 +240,8 @@ class TestDisallowedIds(unittest.IsolatedAsyncioTestCase):
         server._set_version_creation_enabled(True)
         mock = AsyncMock(return_value={"id": 1, "message": "created"})
         with patch.object(
-            server.VersionsApi,
-            "post_version_organizations_organization_id_projects_project_id_versions_post",
+            server,
+            "_create_version_from_archive_with_client",
             mock,
         ), self.assertRaises(RuntimeError) as cm:
             await server.create_version_from_archive(

--- a/src/ah/tests/test_server.py
+++ b/src/ah/tests/test_server.py
@@ -8,6 +8,8 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+from pydantic import ValidationError
+
 from tests.sdk_stubs import install_sdk_stubs
 
 install_sdk_stubs()
@@ -224,6 +226,29 @@ class TestBuildContext(unittest.TestCase):
         self.assertEqual(
             ctx.auth_context.oidc_configuration_url, _FULL_ENV["AUDITHUB_OIDC_CONFIGURATION_URL"]
         )
+
+    def test_orca_task_input_enables_on_chain_when_deployment_info_is_provided(self) -> None:
+        task_input = OrCaTaskInput(
+            specs_override=[OrCaVersionSpecReference(relative_path="specs/invariant.spec")],
+            deployment_info_file="orca/onchain.deployment.json",
+        )
+        self.assertTrue(task_input.on_chain)
+
+    def test_orca_task_input_requires_deployment_info_for_on_chain(self) -> None:
+        with self.assertRaises(ValidationError) as cm:
+            OrCaTaskInput(
+                specs_override=[OrCaVersionSpecReference(relative_path="specs/invariant.spec")],
+                on_chain=True,
+            )
+        self.assertIn("deployment_info_file", str(cm.exception))
+
+    def test_orca_task_input_rejects_non_deployment_json_files(self) -> None:
+        with self.assertRaises(ValidationError) as cm:
+            OrCaTaskInput(
+                specs_override=[OrCaVersionSpecReference(relative_path="specs/invariant.spec")],
+                deployment_info_file="orca/onchain.json",
+            )
+        self.assertIn(".deployment.json", str(cm.exception))
 
     def test_secret_not_in_error_message(self) -> None:
         env = {"AUDITHUB_OIDC_CLIENT_SECRET": "SUPER_SECRET_VALUE"}

--- a/uv.lock
+++ b/uv.lock
@@ -479,11 +479,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -1351,11 +1351,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I noticed this error come up in testing where an agent got stuck trying to debug why a task wasn't in "on-chain" mode. This change seems to have resolved the problem by providing clearer guidance and quicker error messages.