### PR TITLE
Extend ah-mcp to support a finding triage workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 Instructions for AI agents working in this repository.
 
-Repository-wide project details: `./doc/architecture.md`
-Coding conventions: `./doc/conventions.md`
+Repository-wide project details: `./docs/architecture.md`
+Coding conventions: `./docs/llm-conventions.md`
 
 ## Project Structure
 

--- a/docs/prompting.md
+++ b/docs/prompting.md
@@ -13,7 +13,7 @@ Requirements:
 To upload a project, run your agent in the root directory of your project
 directory provide the following prompt:
 
-```
+```text
 Upload this directory as a new version in my NAME project on AuditHub.
 The version name should be VERSION NAME.
 ```
@@ -42,4 +42,43 @@ Example prompt with specific org, project:
 ```
 Execute Vanguard task run with org 112 and project 734 on the latest version.
 Run the reentrancy detector and all ERC20 custom detectors.
+```
+
+## Retrieving and Triaging Findings
+
+After running a tool task that reports findings, you can prompt the agent to
+automatically retrieve the findings and triage them locally (categorize as
+confirmed bug or false alarm).
+
+Assumptions:
+- The task has already finished, and you know the task ID before-hand.
+- The prompt should have enough information to identify the project and organization of the task.
+
+```text
+Retrieve the findings from the logs of each step of task X, in project Y and organization Z.
+Fetch the logs from the task and parse the findings.
+Triage the reported findings by confirming against the project source code.
+```
+
+NOTE: currently, `ah-mcp` does not provide a way to directly obtain findings information
+(as shown in the "Findings" table in the web interface).
+We plan on simplifying the prompting method in the future.
+
+## End-to-End Example
+
+The following prompt template demonstrates how to upload a project, run a DeFi Vanguard
+task, and automatically retrieve and triage the results.
+
+```text
+Upload this directory as a new version in my AuditHub organization's project.
+The version name should be "version-N" where "N" is one more than the largest number of the existing versions.
+Confirm immediately before the upload is performed.
+
+Then execute a DeFi Vanguard V2 task with all built-in detectors on the uploaded version.
+Confirm before executing the task.
+
+Lastly, retrieve task logs for the detector steps and parse the findings.
+Write each full finding title and description to a `./audithub/findings/<task_id>.md` file.
+
+Triage the reported findings by confirming against the project source code.
 ```

--- a/docs/prompting.md
+++ b/docs/prompting.md
@@ -2,9 +2,21 @@
 
 This file is a guide on how to effectively prompt an agent to use AuditHub.
 
-## Uploading Projects
+## Uploading Versions
 
-TODO
+Requirements:
+- Version creation must be enabled in your configuration
+- In order to upload a source code version to AuditHub, you must have an
+  existing configured organization and project set up in your configuration
+  file.
+
+To upload a project, run your agent in the root directory of your project
+directory provide the following prompt:
+
+```
+Upload this directory as a new version in my NAME project on AuditHub.
+The version name should be VERSION NAME.
+```
 
 ## Running OrCa Tasks
 

--- a/src/ah/README.md
+++ b/src/ah/README.md
@@ -133,7 +133,7 @@ credentials and allowlist IDs; no secrets belong in the agent config file.
 | `get_project_comments` | Get all comments for a project across all versions |
 | `run_orca_task` | Start an OrCa task for a project version; registered only when task runs are explicitly enabled |
 | `run_defi_vanguard_task` | Start a DeFi Vanguard task for a project version; registered only when task runs are explicitly enabled |
-| `create_version_from_archive` | Create a project version by uploading a local `.zip` archive; registered only when version creation is explicitly enabled |
+| `create_version_from_file` | Create a project version by uploading a local `.zip` archive; registered only when version creation is explicitly enabled |
 | `create_version_from_url` | Create a project version from a git repository or archive URL; registered only when version creation is explicitly enabled |
 
 All tools return typed Python objects backed by `audithub-sdk` models. On error, tools raise `RuntimeError` with a sanitized plain-text message; the MCP protocol surfaces this as an error response to the caller.

--- a/src/ah/README.md
+++ b/src/ah/README.md
@@ -125,6 +125,7 @@ credentials and allowlist IDs; no secrets belong in the agent config file.
 | `get_task_artifact` | Fetch a task artifact by ID as base64-encoded content |
 | `get_task_logs` | Get logs for a specific step of a task |
 | `get_task_findings` | Get findings produced by a task execution |
+| `parse_findings_from_task_log` | Parse one or more task log files into JSON containing findings plus counts written to a local absolute output path |
 | `get_version_comments` | Get comments for a specific project version |
 | `get_version_comment_threads` | Get comment threads for a specific project version |
 | `get_thread_comments` | Get comments for a specific thread within a project version |
@@ -150,6 +151,7 @@ ID-based tools.
 - **Opt-in DeFi Vanguard task execution.** The `run_defi_vanguard_task` mutation tool is registered under the same task-run opt-in gate. Its inputs are flattened at the top level: `organization_id`, `project_id`, `version_id`, detector selections, and the runtime options. Pass detector selections as two-item JSON arrays `[type, id]`, where builtin selectors use a built-in detector code from `get_defi_vanguard_detectors`, and custom selectors use the catalog id shown by the same tool. The server resolves those selections through the backend detector catalog before calling the generated DeFi Vanguard v2 POST endpoint.
 - **On-chain OrCa mode.** When launching OrCa against already deployed contracts, pass `deployment_info_file` as a path ending in `.deployment.json`. The server normalizes that into `on_chain=True` and rejects mismatched paths early so callers do not accidentally launch a local Foundry-style run.
 - **Opt-in version creation.** The `create_version_from_url` mutation tool is registered only when `AH_ENABLE_VERSION_CREATION=1` or `--enable-version-creation` is supplied. It calls the generated project version URL POST endpoint through `audithub-sdk`.
+- **Local findings parsing.** The `parse_findings_from_task_log` utility tool reads one or more local task log files, extracts findings with the shared log parser, and writes a JSON file containing the parsed findings plus the total finding count and per-log counts. It does not call the AuditHub API.
 - **Detector catalog cache.** The DeFi Vanguard v2 built-in detector list is fetched lazily from the AuditHub configuration endpoint and cached in-process for one day. Custom detectors are fetched live on each request from both the organization library and the standard library.
 - **Detector listing format.** `get_defi_vanguard_detectors` returns one block per detector. Each block starts with `detector: <json>` where `<json>` is a JSON value matching `DefiVanguardV2DetectorSelectionInput`, followed by `title:`. Standard-library custom detectors also include `description:` loaded from the detector payload. Each block ends with `------`.
 - **Credential isolation.** OIDC credentials are read from the environment once at startup and passed into `audithub_sdk_ext.AuthenticatedApiClient`. They are never accepted as tool arguments and are not surfaced in tool outputs or sanitized error messages.

--- a/src/ah/README.md
+++ b/src/ah/README.md
@@ -125,6 +125,7 @@ credentials and allowlist IDs; no secrets belong in the agent config file.
 | `get_task_artifact` | Fetch a task artifact by ID as base64-encoded content |
 | `get_task_logs` | Get logs for one or more steps of a task and write each result to a local output file |
 | `get_task_findings` | Fetch findings for a task and write them to a local output file |
+| `wait_for_task_completion` | Poll a task until no pending steps remain or the timeout is reached, then return the latest task snapshot and completion state; with no timeout, task-capable clients can invoke it as a task |
 | `parse_findings_from_task_log` | Parse one or more task log files into JSON containing findings plus counts written to a local absolute output path |
 | `get_version_comments` | Get comments for a specific project version |
 | `get_version_comment_threads` | Get comment threads for a specific project version |
@@ -147,6 +148,7 @@ ID-based tools.
 ## Security model
 
 - **Read-only by default.** Default tools are named `get_*` and only invoke generated `audithub-sdk` GET endpoints.
+- **Task completion polling.** `wait_for_task_completion` repeatedly fetches task details until no pending steps remain or the timeout is reached, then returns the latest sanitized `Task` snapshot with a boolean completion flag. When called with no timeout by a task-capable client, it can run as a task instead of blocking the request.
 - **Opt-in OrCa task execution.** The `run_orca_task` mutation tool is registered only when `AH_ENABLE_TASK_RUNS=1` or `--enable-task-runs` is supplied. It calls the generated OrCa POST endpoint through `audithub-sdk`.
 - **Opt-in DeFi Vanguard task execution.** The `run_defi_vanguard_task` mutation tool is registered under the same task-run opt-in gate. Its inputs are flattened at the top level: `organization_id`, `project_id`, `version_id`, detector selections, and the runtime options. Pass detector selections as two-item JSON arrays `[type, id]`, where builtin selectors use a built-in detector code from `get_defi_vanguard_detectors`, and custom selectors use the catalog id shown by the same tool. The server resolves those selections through the backend detector catalog before calling the generated DeFi Vanguard v2 POST endpoint.
 - **On-chain OrCa mode.** When launching OrCa against already deployed contracts, pass `deployment_info_file` as a path ending in `.deployment.json`. The server normalizes that into `on_chain=True` and rejects mismatched paths early so callers do not accidentally launch a local Foundry-style run.

--- a/src/ah/README.md
+++ b/src/ah/README.md
@@ -123,7 +123,7 @@ credentials and allowlist IDs; no secrets belong in the agent config file.
 | `get_task_info` | Get status and details for an AuditHub task |
 | `get_task_artifacts` | List sanitized artifact metadata for an AuditHub task |
 | `get_task_artifact` | Fetch a task artifact by ID as base64-encoded content |
-| `get_task_logs` | Get logs for a specific step of a task and write them to a local output file |
+| `get_task_logs` | Get logs for one or more steps of a task and write each result to a local output file |
 | `get_task_findings` | Fetch findings for a task and write them to a local output file |
 | `parse_findings_from_task_log` | Parse one or more task log files into JSON containing findings plus counts written to a local absolute output path |
 | `get_version_comments` | Get comments for a specific project version |

--- a/src/ah/README.md
+++ b/src/ah/README.md
@@ -123,8 +123,8 @@ credentials and allowlist IDs; no secrets belong in the agent config file.
 | `get_task_info` | Get status and details for an AuditHub task |
 | `get_task_artifacts` | List sanitized artifact metadata for an AuditHub task |
 | `get_task_artifact` | Fetch a task artifact by ID as base64-encoded content |
-| `get_task_logs` | Get logs for a specific step of a task |
-| `get_task_findings` | Get findings produced by a task execution |
+| `get_task_logs` | Get logs for a specific step of a task and write them to a local output file |
+| `get_task_findings` | Fetch findings for a task and write them to a local output file |
 | `parse_findings_from_task_log` | Parse one or more task log files into JSON containing findings plus counts written to a local absolute output path |
 | `get_version_comments` | Get comments for a specific project version |
 | `get_version_comment_threads` | Get comment threads for a specific project version |

--- a/src/ah/src/ah_mcp/audit.py
+++ b/src/ah/src/ah_mcp/audit.py
@@ -14,13 +14,13 @@ logger = logging.getLogger("ah_mcp.audit")
 _MAX_ERROR_LEN: int = 200
 
 
-def log_call_start(tool_name: str, safe_args: dict[str, int | None]) -> None:
+def log_call_start(tool_name: str, safe_args: dict[str, int | float | None]) -> None:
     """Log the start of a tool call at INFO level.
 
     Args:
         tool_name: Name of the MCP tool being called.
-        safe_args: Numeric tool arguments safe to include in logs.  Restricted to
-            ``int | None`` values to prevent accidental logging of free-text API
+        safe_args: Numeric tool arguments safe to include in logs. Restricted to
+            ``int | float | None`` values to prevent accidental logging of free-text API
             response content that could carry prompt-injection payloads.
     """
     arg_str = " ".join(f"{k}={v!r}" for k, v in safe_args.items())

--- a/src/ah/src/ah_mcp/models.py
+++ b/src/ah/src/ah_mcp/models.py
@@ -105,6 +105,15 @@ class TaskArtifactContent(BaseModel):
     content_type: str | None = None
 
 
+class FindingsParseResult(BaseModel):
+    """Summary returned after parsing a task log into findings JSON."""
+
+    model_config = ConfigDict(frozen=True)
+
+    num_findings: Annotated[int, Field(ge=0)]
+    num_findings_by_log_file_path: dict[str, Annotated[int, Field(ge=0)]]
+
+
 DefiVanguardV2DetectorSelectionInput = tuple[
     Literal["builtin", "stdlib", "orglib", "version"],
     str | int,
@@ -378,6 +387,7 @@ __all__ = [
     "TaskArtifact",
     "TaskArtifactContent",
     "TaskCreation",
+    "FindingsParseResult",
     "Thread",
     "Version",
     "VersionFromFileInput",

--- a/src/ah/src/ah_mcp/models.py
+++ b/src/ah/src/ah_mcp/models.py
@@ -114,6 +114,14 @@ class FindingsParseResult(BaseModel):
     num_findings_by_log_file_path: dict[str, Annotated[int, Field(ge=0)]]
 
 
+class TaskLogsWriteResult(BaseModel):
+    """Summary returned after writing task logs to a local file."""
+
+    model_config = ConfigDict(frozen=True)
+
+    num_logs: Annotated[int, Field(ge=0)]
+
+
 DefiVanguardV2DetectorSelectionInput = tuple[
     Literal["builtin", "stdlib", "orglib", "version"],
     str | int,
@@ -388,6 +396,7 @@ __all__ = [
     "TaskArtifactContent",
     "TaskCreation",
     "FindingsParseResult",
+    "TaskLogsWriteResult",
     "Thread",
     "Version",
     "VersionFromFileInput",

--- a/src/ah/src/ah_mcp/models.py
+++ b/src/ah/src/ah_mcp/models.py
@@ -122,6 +122,23 @@ class TaskLogsWriteResult(BaseModel):
     num_logs: Annotated[int, Field(ge=0)]
 
 
+class WaitForTaskCompletionResult(BaseModel):
+    """Result returned after waiting for a task to complete or timing out."""
+
+    model_config = ConfigDict(frozen=True)
+
+    task: Annotated[Task, Field(description="Latest task snapshot observed by the waiter.")]
+    is_completed: Annotated[
+        bool,
+        Field(
+            description=(
+                "True when the task finished before polling stopped. False when polling stopped "
+                "because the timeout was reached while the task still had pending steps."
+            ),
+        ),
+    ]
+
+
 DefiVanguardV2DetectorSelectionInput = tuple[
     Literal["builtin", "stdlib", "orglib", "version"],
     str | int,

--- a/src/ah/src/ah_mcp/models.py
+++ b/src/ah/src/ah_mcp/models.py
@@ -61,7 +61,7 @@ class VersionFromUrlInput(BaseModel):
     includes_submodules: bool | None = None
 
 
-class VersionFromArchiveInput(BaseModel):
+class VersionFromFileInput(BaseModel):
     """Input payload for creating an AuditHub project version from a .zip archive."""
 
     model_config = ConfigDict(frozen=True)
@@ -380,6 +380,6 @@ __all__ = [
     "TaskCreation",
     "Thread",
     "Version",
-    "VersionFromArchiveInput",
+    "VersionFromFileInput",
     "VersionNameIndexEntry",
 ]

--- a/src/ah/src/ah_mcp/models.py
+++ b/src/ah/src/ah_mcp/models.py
@@ -24,7 +24,7 @@ class OrganizationNameIndexEntry(BaseModel):
 
     id: int
     name: str
-    lookup_key: str
+    sort_key: str
 
 
 class ProjectNameIndexEntry(BaseModel):
@@ -34,7 +34,7 @@ class ProjectNameIndexEntry(BaseModel):
 
     id: int
     name: str
-    lookup_key: str
+    sort_key: str
 
 
 class VersionNameIndexEntry(BaseModel):
@@ -44,7 +44,7 @@ class VersionNameIndexEntry(BaseModel):
 
     id: int
     name: str
-    lookup_key: str
+    sort_key: str
 
 
 class VersionFromUrlInput(BaseModel):

--- a/src/ah/src/ah_mcp/parse_fio_logs.py
+++ b/src/ah/src/ah_mcp/parse_fio_logs.py
@@ -1,0 +1,142 @@
+"""Parse task log contents to extract finding summaries.
+
+This module contains placeholder logic for parsing FIO findings from tool
+task logs.
+
+It is intended to be removed in the future once we have direct access to the
+FIO SDK to format FIO analysis result data.
+
+The parser is intentionally conservative:
+- It only extracts `title`, `detector`, and `description`.
+- It ignores all other log fields.
+- It returns a dataclass wrapper containing the parsed findings plus total
+  and per-log finding counts.
+
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Finding:
+    title: str
+    detector: str
+    description: str
+
+
+@dataclass(frozen=True)
+class ParsedLogs:
+    findings: list[Finding]
+    num_findings: int
+    num_findings_by_log_file_path: dict[str, int]
+
+
+_FINDING_START_RE = re.compile(r"^\[(?P<severity>[^\]]+)\]\s+(?P<title>.+?)\s*$")
+_DETECTOR_RE = re.compile(r"^Reported By:\s*vanguard:(?P<detector>[^\s]+)\s*$")
+_DESCRIPTION_RE = re.compile(r"^Details:\s*$")
+
+
+def _parse_findings_from_log_contents(log_contents: str) -> list[Finding]:
+    """Parse detector findings from a single task log string.
+
+    A finding is expected to look like:
+
+        + [Medium] Some title
+        Reported By: vanguard:some/detector
+        Location: ...
+        Confidence: ...
+        More Info: ...
+        Details:
+        Description line 1
+        Description line 2
+
+    Only the title, detector, and description are preserved.
+    """
+
+    findings: list[Finding] = []
+    lines = log_contents.splitlines()
+
+    i = 0
+    while i < len(lines):
+        current = lines[i].lstrip()
+        start_match = _FINDING_START_RE.match(current)
+        if start_match is None:
+            i += 1
+            continue
+
+        title = start_match.group("title").strip()
+        detector = ""
+        description_lines: list[str] = []
+
+        i += 1
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.lstrip()
+
+            # A new finding begins; stop here and let the outer loop process it.
+            if _FINDING_START_RE.match(stripped):
+                break
+
+            detector_match = _DETECTOR_RE.match(stripped)
+            if detector_match is not None:
+                detector = detector_match.group("detector").strip()
+                i += 1
+                continue
+
+            if _DESCRIPTION_RE.match(stripped):
+                i += 1
+                while i < len(lines):
+                    desc_line = lines[i]
+                    stripped_desc = desc_line.lstrip()
+                    if _FINDING_START_RE.match(stripped_desc):
+                        break
+                    if stripped_desc.startswith("finding_counters_file="):
+                        break
+                    if description_lines and not stripped_desc and stripped_desc != "":
+                        break
+                    if stripped_desc == "":
+                        description_lines.append("")
+                        i += 1
+                        continue
+                    if stripped_desc.startswith("["):
+                        break
+                    description_lines.append(
+                        desc_line[1:] if desc_line.startswith(" ") else desc_line
+                    )
+                    i += 1
+                continue
+
+            i += 1
+
+        description = "\n".join(line.rstrip() for line in description_lines).strip()
+        findings.append(Finding(title=title, detector=detector, description=description))
+
+    return findings
+
+
+def parse_logs(logs: Sequence[tuple[str, str]]) -> ParsedLogs:
+    """Parse detector findings from one or more task log strings.
+
+    Each log entry is a ``(log_file_path, log_contents)`` tuple.
+    """
+
+    findings: list[Finding] = []
+    num_findings_by_log_file_path: dict[str, int] = {}
+    total_findings = 0
+
+    for log_file_path, log_contents in logs:
+        log_findings = _parse_findings_from_log_contents(log_contents)
+        finding_count = len(log_findings)
+        findings.extend(log_findings)
+        num_findings_by_log_file_path[log_file_path] = finding_count
+        total_findings += finding_count
+
+    return ParsedLogs(
+        findings=findings,
+        num_findings=total_findings,
+        num_findings_by_log_file_path=num_findings_by_log_file_path,
+    )

--- a/src/ah/src/ah_mcp/server.py
+++ b/src/ah/src/ah_mcp/server.py
@@ -17,7 +17,7 @@ import json
 import sys
 import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Annotated
 
@@ -53,12 +53,13 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import Field, TypeAdapter, ValidationError
 
 from ah_mcp import config as server_config
-from ah_mcp import vanguard
+from ah_mcp import parse_fio_logs, vanguard
 from ah_mcp.audit import log_call_error, log_call_start, log_call_success
 from ah_mcp.models import (
     Comment,
     DefiVanguardV2DetectorSelectionInput,
     DefiVanguardV2TaskInput,
+    FindingsParseResult,
     FIOData,
     IssueDetails,
     IssueForList,
@@ -133,6 +134,7 @@ _SdkOrCaHintActual = (
     HintFromVersion | HintFromStandardLibrary | HintFromOrganizationLibrary | HintAdHoc
 )
 
+_PARSE_FINDINGS_FROM_TASK_LOG_TOOL_NAME = "parse_findings_from_task_log"
 
 @dataclass(frozen=True)
 class RegisteredTool:
@@ -416,6 +418,15 @@ def _response_header(headers: Mapping[str, str] | None, name: str) -> str | None
         if key.casefold() == folded_name:
             return value
     return None
+
+
+def _write_output_file(output_file_path: str, contents: str) -> None:
+    """Write text content to a local file with a sanitized error message."""
+    output_path = Path(output_file_path)
+    try:
+        output_path.write_text(contents, encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Failed to write output file {output_path!s}: {exc}") from None
 
 
 async def _with_api_client[T](fn: Callable[[AuthenticatedApiClient], Awaitable[T]]) -> T:
@@ -786,6 +797,48 @@ async def get_task_logs(organization_id: _AhId, task_id: _AhId, step_code: str) 
         tool_name="get_task_logs",
         safe_args={"organization_id": organization_id, "task_id": task_id},
     )
+
+
+@mcp.tool()
+async def parse_findings_from_task_log(
+    log_file_paths: Annotated[
+        list[str],
+        Field(
+            min_length=1,
+            description="Absolute paths to one or more task log files to parse.",
+        ),
+    ],
+    output_file_path: Annotated[
+        str,
+        Field(min_length=1, description="Absolute path to write the JSON summary to."),
+    ],
+) -> FindingsParseResult:
+    """Parse findings from one or more task log files (as retrieved with get_task_logs)
+    and write a JSON summary.
+    """
+
+    async def _run() -> FindingsParseResult:
+        log_entries: list[tuple[str, str]] = []
+        for log_file_path in log_file_paths:
+            log_path = Path(log_file_path)
+            try:
+                log_contents = log_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                raise RuntimeError(f"Failed to read log file {log_path!s}: {exc}") from None
+            log_entries.append((log_file_path, log_contents))
+
+        parsed = parse_fio_logs.parse_logs(log_entries)
+        payload = asdict(parsed)
+        _write_output_file(
+            output_file_path,
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        )
+        return FindingsParseResult(
+            num_findings=parsed.num_findings,
+            num_findings_by_log_file_path=parsed.num_findings_by_log_file_path,
+        )
+
+    return await _run_tool(_run, tool_name="parse_findings_from_task_log")
 
 
 @mcp.tool()

--- a/src/ah/src/ah_mcp/server.py
+++ b/src/ah/src/ah_mcp/server.py
@@ -19,7 +19,7 @@ import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any, cast
 
 import audithub_sdk
 from audithub_sdk.api.configuration_api import ConfigurationApi
@@ -49,7 +49,9 @@ from audithub_sdk.models.v_spec_from_organization_library import VSpecFromOrgani
 from audithub_sdk.models.v_spec_from_standard_library import VSpecFromStandardLibrary
 from audithub_sdk.models.v_spec_from_version import VSpecFromVersion
 from audithub_sdk_ext import AuthenticatedApiClient, OIDCClientCredentialsContext
-from mcp.server.fastmcp import FastMCP
+from mcp import types as mcp_types
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.shared.exceptions import McpError
 from pydantic import Field, TypeAdapter, ValidationError
 
 from ah_mcp import config as server_config
@@ -90,6 +92,7 @@ from ah_mcp.models import (
     VersionFromFileInput,
     VersionFromUrlInput,
     VersionNameIndexEntry,
+    WaitForTaskCompletionResult,
 )
 
 _AhId = server_config._AhId
@@ -109,6 +112,7 @@ __all__ = [
 ]
 
 mcp = FastMCP("ah")
+mcp._mcp_server.experimental.enable_tasks()
 
 
 _context: AuditHubSdkContext | None = None
@@ -135,7 +139,19 @@ _SdkOrCaHintActual = (
     HintFromVersion | HintFromStandardLibrary | HintFromOrganizationLibrary | HintAdHoc
 )
 
-_PARSE_FINDINGS_FROM_TASK_LOG_TOOL_NAME = "parse_findings_from_task_log"
+_WAIT_FOR_TASK_COMPLETION_TOOL_NAME = "wait_for_task_completion"
+_TASK_COMPLETION_POLL_INTERVAL_SECONDS = 10.0
+_PENDING_STEP_STATUSES = {"pending", "queued", "running", "started", "in_progress"}
+_TERMINAL_TASK_STATUSES = {
+    "finished",
+    "failed",
+    "succeeded",
+    "success",
+    "completed",
+    "cancelled",
+    "canceled",
+    "skipped",
+}
 
 
 @dataclass(frozen=True)
@@ -411,6 +427,13 @@ def _task_artifacts(task: Task) -> list[TaskArtifact]:
     ]
 
 
+def _task_has_pending_steps(task: Task) -> bool:
+    """Return whether *task* still has at least one pending step."""
+    if task.steps is None:
+        return task.status.casefold() not in _TERMINAL_TASK_STATUSES
+    return any(step.status.casefold() in _PENDING_STEP_STATUSES for step in task.steps)
+
+
 def _response_header(headers: Mapping[str, str] | None, name: str) -> str | None:
     """Read a response header without depending on a concrete header mapping type."""
     if headers is None:
@@ -450,7 +473,7 @@ async def _run_tool[T](
     fn: Callable[[], T | Awaitable[T]],
     *,
     tool_name: str = "",
-    safe_args: dict[str, int | None] | None = None,
+    safe_args: dict[str, int | float | None] | None = None,
 ) -> T:
     """Execute a tool function, sanitizing exceptions to prevent secret leakage."""
     if tool_name:
@@ -469,6 +492,10 @@ async def _run_tool[T](
             log_call_error(tool_name, str(exc), (time.monotonic() - start) * 1000)
         exc.__context__ = None
         exc.__cause__ = None
+        raise
+    except McpError as exc:
+        if tool_name:
+            log_call_error(tool_name, str(exc), (time.monotonic() - start) * 1000)
         raise
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000
@@ -712,6 +739,104 @@ async def get_task_info(organization_id: _AhId, task_id: _AhId) -> Task:
 
 
 @mcp.tool()
+async def wait_for_task_completion(
+    organization_id: _AhId,
+    task_id: _AhId,
+    timeout: Annotated[
+        float | None,
+        Field(
+            gt=0,
+            description=(
+                "Maximum number of seconds to wait before stopping polling. "
+                "For an agent with no MCP task protocol support, this should be set to a value "
+                "slightly below the tool call timeout."
+            ),
+        ),
+    ] = None,
+    context: Context[Any, Any, Any] | None = None,
+) -> WaitForTaskCompletionResult | mcp_types.CreateTaskResult:
+    """Poll an AuditHub task until it has no pending steps left or a timeout is reached, then
+    return its current task info.
+
+    This tool can be called repeatedly until the task is complete."""
+
+    async def _wait_for_audithub_task_completion() -> WaitForTaskCompletionResult:
+        _assert_org_allowed(organization_id)
+        deadline = None if timeout is None else time.monotonic() + timeout
+        latest_task: Task | None = None
+        while True:
+            # Stop immediately once the deadline has passed and return the latest snapshot.
+            now = time.monotonic()
+            if deadline is not None and now >= deadline:
+                if latest_task is None:
+                    task = await _with_api_client(
+                        lambda client: TasksApi(
+                            client
+                        ).get_info_organizations_organization_id_tasks_task_id_get(  # noqa: E501
+                            organization_id=organization_id,
+                            task_id=task_id,
+                        )
+                    )
+                    latest_task = _sanitize_task(Task.model_validate(task))
+                return WaitForTaskCompletionResult(task=latest_task, is_completed=False)
+
+            # Fetch the current task state before deciding whether to keep polling.
+            task = await _with_api_client(
+                lambda client: TasksApi(
+                    client
+                ).get_info_organizations_organization_id_tasks_task_id_get(  # noqa: E501
+                    organization_id=organization_id,
+                    task_id=task_id,
+                )
+            )
+            now = time.monotonic()
+            validated_task = _sanitize_task(Task.model_validate(task))
+            latest_task = validated_task
+
+            # The task is finished, so return the final snapshot immediately.
+            if not _task_has_pending_steps(validated_task):
+                return WaitForTaskCompletionResult(task=validated_task, is_completed=True)
+
+            # No timeout means a plain polling loop with the configured interval.
+            if deadline is None:
+                await asyncio.sleep(_TASK_COMPLETION_POLL_INTERVAL_SECONDS)
+                continue
+
+            # Sleep only for the remaining time so short timeouts stay precise.
+            remaining = deadline - now
+            if remaining <= 0:
+                return WaitForTaskCompletionResult(task=validated_task, is_completed=False)
+            await asyncio.sleep(min(_TASK_COMPLETION_POLL_INTERVAL_SECONDS, remaining))
+
+    if context is not None and context.request_context.experimental.is_task and timeout is None:
+        # Task-capable clients can run the indefinite wait as a background task.
+        async def _run_as_task() -> mcp_types.CreateTaskResult:
+            async def _work(task: object) -> mcp_types.CallToolResult:
+                result = await _wait_for_audithub_task_completion()
+                return mcp_types.CallToolResult(content=[], structuredContent=result.model_dump())
+
+            # `experimental.run_task` is typed as `Any` by the MCP library, so cast the
+            # awaited value back to the concrete result type this branch returns.
+            return cast(
+                mcp_types.CreateTaskResult,
+                await context.request_context.experimental.run_task(_work),
+            )
+
+        # Non-task clients fall through to the normal tool return path.
+        return await _run_tool(
+            _run_as_task,
+            tool_name=_WAIT_FOR_TASK_COMPLETION_TOOL_NAME,
+            safe_args={"organization_id": organization_id, "task_id": task_id, "timeout": timeout},
+        )
+
+    return await _run_tool(
+        _wait_for_audithub_task_completion,
+        tool_name=_WAIT_FOR_TASK_COMPLETION_TOOL_NAME,
+        safe_args={"organization_id": organization_id, "task_id": task_id, "timeout": timeout},
+    )
+
+
+@mcp.tool()
 async def get_task_artifacts(organization_id: _AhId, task_id: _AhId) -> list[TaskArtifact]:
     """List metadata of all artifacts produced by an AuditHub task."""
 
@@ -914,7 +1039,10 @@ async def get_task_findings(
             )
             + "\n",
         )
-        return FindingsParseResult(num_findings=len(validated_findings))
+        return FindingsParseResult(
+            num_findings=len(validated_findings),
+            num_findings_by_log_file_path={},
+        )
 
     return await _run_tool(
         _run,
@@ -1470,6 +1598,28 @@ _VERSION_CREATION_TOOLS = (
     RegisteredTool(_CREATE_VERSION_FROM_FILE_TOOL_NAME, create_version_from_file),
     RegisteredTool(_CREATE_VERSION_FROM_URL_TOOL_NAME, create_version_from_url),
 )
+
+
+def _mark_wait_for_task_completion_as_task_required() -> None:
+    """Advertise ``wait_for_task_completion`` as task-required in tool listings."""
+    original_handler = mcp._mcp_server.request_handlers[mcp_types.ListToolsRequest]
+
+    async def _handler(request: mcp_types.ListToolsRequest) -> mcp_types.ServerResult:
+        result = await original_handler(request)
+        list_tools_result = result.root
+        if isinstance(list_tools_result, mcp_types.ListToolsResult):
+            for tool in list_tools_result.tools:
+                if tool.name != _WAIT_FOR_TASK_COMPLETION_TOOL_NAME:
+                    continue
+                tool.execution = mcp_types.ToolExecution(taskSupport=mcp_types.TASK_OPTIONAL)
+                mcp._mcp_server._tool_cache[tool.name] = tool
+                break
+        return result
+
+    mcp._mcp_server.request_handlers[mcp_types.ListToolsRequest] = _handler
+
+
+_mark_wait_for_task_completion_as_task_required()
 
 
 def main() -> None:

--- a/src/ah/src/ah_mcp/server.py
+++ b/src/ah/src/ah_mcp/server.py
@@ -83,6 +83,7 @@ from ah_mcp.models import (
     TaskArtifact,
     TaskArtifactContent,
     TaskCreation,
+    TaskLogsWriteResult,
     Thread,
     Version,
     VersionCreation,
@@ -776,10 +777,15 @@ async def get_task_artifact(
 
 
 @mcp.tool()
-async def get_task_logs(organization_id: _AhId, task_id: _AhId, step_code: str) -> list[str]:
+async def get_task_logs(
+    organization_id: _AhId,
+    task_id: _AhId,
+    step_code: str,
+    output_file_path: Annotated[str, Field(min_length=1)],
+) -> TaskLogsWriteResult:
     """Get logs for a specific step of an AuditHub task."""
 
-    async def _run() -> list[str]:
+    async def _run() -> TaskLogsWriteResult:
         _assert_org_allowed(organization_id)
         logs = await _with_api_client(
             lambda client: TasksApi(
@@ -790,7 +796,12 @@ async def get_task_logs(organization_id: _AhId, task_id: _AhId, step_code: str) 
                 step_code=step_code,
             )
         )
-        return _str_list_ta.validate_python(logs)
+        validated_logs = _str_list_ta.validate_python(logs)
+        _write_output_file(
+            output_file_path,
+            "\n".join(validated_logs) + ("\n" if validated_logs else ""),
+        )
+        return TaskLogsWriteResult(num_logs=len(validated_logs))
 
     return await _run_tool(
         _run,
@@ -842,12 +853,16 @@ async def parse_findings_from_task_log(
 
 
 @mcp.tool()
-async def get_task_findings(organization_id: _AhId, task_id: _AhId) -> list[FIOData]:
+async def get_task_findings(
+    organization_id: _AhId,
+    task_id: _AhId,
+    output_file_path: Annotated[str, Field(min_length=1)],
+) -> FindingsParseResult:
     """Get raw findings data produced by an AuditHub task execution.
 
     This data is large and should not be read directly."""
 
-    async def _run() -> list[FIOData]:
+    async def _run() -> FindingsParseResult:
         _assert_org_allowed(organization_id)
         findings = await _with_api_client(
             lambda client: TasksApi(
@@ -857,7 +872,17 @@ async def get_task_findings(organization_id: _AhId, task_id: _AhId) -> list[FIOD
                 task_id=task_id,
             )
         )
-        return _fio_data_ta.validate_python(findings)
+        validated_findings = _fio_data_ta.validate_python(findings)
+        _write_output_file(
+            output_file_path,
+            json.dumps(
+                {"findings": [finding.model_dump(mode="json") for finding in validated_findings]},
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+        )
+        return FindingsParseResult(num_findings=len(validated_findings))
 
     return await _run_tool(
         _run,

--- a/src/ah/src/ah_mcp/server.py
+++ b/src/ah/src/ah_mcp/server.py
@@ -385,8 +385,8 @@ def _slice_paginated[T](items: Sequence[T], limit: int | None, offset: int | Non
     return list(items[start:end])
 
 
-def _normalize_lookup_key(name: str) -> str:
-    """Normalize a user-visible name into a deterministic case-insensitive lookup key."""
+def _normalize_sort_key(name: str) -> str:
+    """Normalize a user-visible name into a deterministic case-insensitive sort key."""
     return name.strip().casefold()
 
 
@@ -478,7 +478,7 @@ async def _run_tool[T](
 
 @mcp.tool()
 async def get_my_organizations() -> list[MyOrganization]:
-    """List AuditHub organizations the authenticated user belongs to."""
+    """List details of all AuditHub organizations."""
 
     async def _run() -> list[MyOrganization]:
         organizations = await _with_api_client(
@@ -492,7 +492,7 @@ async def get_my_organizations() -> list[MyOrganization]:
 
 @mcp.tool()
 async def get_organization_name_index() -> list[OrganizationNameIndexEntry]:
-    """List allowlisted AuditHub organizations as deterministic name lookup entries."""
+    """List AuditHub organizations as name and organization id entries."""
 
     async def _run() -> list[OrganizationNameIndexEntry]:
         organizations = await _with_api_client(
@@ -503,12 +503,12 @@ async def get_organization_name_index() -> list[OrganizationNameIndexEntry]:
             OrganizationNameIndexEntry(
                 id=org.id,
                 name=org.name,
-                lookup_key=_normalize_lookup_key(org.name),
+                sort_key=_normalize_sort_key(org.name),
             )
             for org in orgs
             if org.id in _allowed_org_ids
         ]
-        return sorted(entries, key=lambda entry: (entry.lookup_key, entry.id))
+        return sorted(entries, key=lambda entry: (entry.sort_key, entry.id))
 
     return await _run_tool(_run, tool_name="get_organization_name_index", safe_args={})
 
@@ -539,7 +539,7 @@ async def get_defi_vanguard_detectors(organization_id: _AhId) -> list[str]:
         )
         entries = sorted(
             [*builtin_entries, *custom_entries],
-            key=lambda entry: (_normalize_lookup_key(entry.display_name), entry.description),
+            key=lambda entry: (_normalize_sort_key(entry.display_name), entry.description),
         )
         return [vanguard.format_vanguard_detector_listing_entry(entry) for entry in entries]
 
@@ -576,7 +576,7 @@ async def get_project(organization_id: _AhId, project_id: _AhId) -> Project:
 
 @mcp.tool()
 async def get_project_name_index(organization_id: _AhId) -> list[ProjectNameIndexEntry]:
-    """List allowlisted projects in an organization as deterministic name lookup entries."""
+    """List projects in an organization as name and project id entries."""
 
     async def _run() -> list[ProjectNameIndexEntry]:
         _assert_org_allowed(organization_id)
@@ -605,10 +605,10 @@ async def get_project_name_index(organization_id: _AhId) -> list[ProjectNameInde
                 ProjectNameIndexEntry(
                     id=validated_project.id,
                     name=validated_project.name,
-                    lookup_key=_normalize_lookup_key(validated_project.name),
+                    sort_key=_normalize_sort_key(validated_project.name),
                 )
             )
-        return sorted(entries, key=lambda entry: (entry.lookup_key, entry.id))
+        return sorted(entries, key=lambda entry: (entry.sort_key, entry.id))
 
     return await _run_tool(
         _run,
@@ -619,7 +619,7 @@ async def get_project_name_index(organization_id: _AhId) -> list[ProjectNameInde
 
 @mcp.tool()
 async def get_latest_version(organization_id: _AhId, project_id: _AhId) -> Version:
-    """Get the latest version of an AuditHub project."""
+    """Get the latest version details of an AuditHub project."""
 
     async def _run() -> Version:
         _assert_org_allowed(organization_id)
@@ -645,7 +645,7 @@ async def get_latest_version(organization_id: _AhId, project_id: _AhId) -> Versi
 async def get_version_name_index(
     organization_id: _AhId, project_id: _AhId
 ) -> list[VersionNameIndexEntry]:
-    """List project versions as deterministic name lookup entries."""
+    """List project versions as name and version id entries."""
 
     async def _run() -> list[VersionNameIndexEntry]:
         _assert_org_allowed(organization_id)
@@ -662,11 +662,11 @@ async def get_version_name_index(
             VersionNameIndexEntry(
                 id=version.id,
                 name=version.name,
-                lookup_key=_normalize_lookup_key(version.name),
+                sort_key=_normalize_sort_key(version.name),
             )
             for version in _version_ta.validate_python(versions)
         ]
-        return sorted(entries, key=lambda entry: (entry.lookup_key, entry.id))
+        return sorted(entries, key=lambda entry: (entry.sort_key, entry.id))
 
     return await _run_tool(
         _run,
@@ -700,7 +700,7 @@ async def get_task_info(organization_id: _AhId, task_id: _AhId) -> Task:
 
 @mcp.tool()
 async def get_task_artifacts(organization_id: _AhId, task_id: _AhId) -> list[TaskArtifact]:
-    """List sanitized artifact metadata for an AuditHub task."""
+    """List metadata of all artifacts produced by an AuditHub task."""
 
     async def _run() -> list[TaskArtifact]:
         _assert_org_allowed(organization_id)
@@ -728,7 +728,7 @@ async def get_task_artifact(
     artifact_id: _ArtifactId,
     max_bytes: _MaxBytes | None = _DEFAULT_ARTIFACT_MAX_BYTES,
 ) -> TaskArtifactContent:
-    """Fetch an AuditHub task artifact as base64-encoded content."""
+    """Download the artifact blob of an AuditHub task as base64-encoded content."""
 
     async def _run() -> TaskArtifactContent:
         _assert_org_allowed(organization_id)
@@ -790,7 +790,9 @@ async def get_task_logs(organization_id: _AhId, task_id: _AhId, step_code: str) 
 
 @mcp.tool()
 async def get_task_findings(organization_id: _AhId, task_id: _AhId) -> list[FIOData]:
-    """Get findings produced by an AuditHub task execution."""
+    """Get raw findings data produced by an AuditHub task execution.
+
+    This data is large and should not be read directly."""
 
     async def _run() -> list[FIOData]:
         _assert_org_allowed(organization_id)
@@ -1278,7 +1280,7 @@ async def create_version_from_file(
     project_id: _AhId,
     version_input: VersionFromFileInput,
 ) -> VersionCreation:
-    """Create an AuditHub project version by uploading a local .zip archive."""
+    """Create an AuditHub project version by uploading a .zip file of the project source code."""
 
     async def _run() -> VersionCreation:
         _assert_version_creation_enabled()

--- a/src/ah/src/ah_mcp/server.py
+++ b/src/ah/src/ah_mcp/server.py
@@ -137,6 +137,7 @@ _SdkOrCaHintActual = (
 
 _PARSE_FINDINGS_FROM_TASK_LOG_TOOL_NAME = "parse_findings_from_task_log"
 
+
 @dataclass(frozen=True)
 class RegisteredTool:
     """Name and callable pair for opt-in MCP tools."""
@@ -780,28 +781,59 @@ async def get_task_artifact(
 async def get_task_logs(
     organization_id: _AhId,
     task_id: _AhId,
-    step_code: str,
-    output_file_path: Annotated[str, Field(min_length=1)],
+    step_codes: Annotated[
+        list[str],
+        Field(
+            min_length=1,
+            description=(
+                "List of task step codes to fetch logs for. Each step code is paired "
+                "with the output path at the same index."
+            ),
+        ),
+    ],
+    output_paths: Annotated[
+        list[str],
+        Field(
+            min_length=1,
+            description=(
+                "List of local absolute output file paths to write the logs to. The number of "
+                "output paths must match the number of step codes so each log is "
+                "written to a separate file."
+            ),
+        ),
+    ],
 ) -> TaskLogsWriteResult:
-    """Get logs for a specific step of an AuditHub task."""
+    """Get logs for one or more AuditHub task steps and write each to a file.
+
+    Findings can be parsed from the logs with the parse_findings_from_task_log tool.
+    """
 
     async def _run() -> TaskLogsWriteResult:
         _assert_org_allowed(organization_id)
-        logs = await _with_api_client(
-            lambda client: TasksApi(
-                client
-            ).get_output_organizations_organization_id_tasks_task_id_step_code_output_get(  # noqa: E501
-                organization_id=organization_id,
-                task_id=task_id,
-                step_code=step_code,
+        if len(step_codes) != len(output_paths):
+            raise ValueError("step_codes and output_paths must have the same length.")
+
+        total_logs = 0
+        for step_code, output_file_path in zip(step_codes, output_paths, strict=True):
+
+            async def _fetch_logs(client: object, step_code: str = step_code) -> object:
+                return await TasksApi(
+                    client
+                ).get_output_organizations_organization_id_tasks_task_id_step_code_output_get(  # noqa: E501
+                    organization_id=organization_id,
+                    task_id=task_id,
+                    step_code=step_code,
+                )
+
+            logs = await _with_api_client(_fetch_logs)
+            validated_logs = _str_list_ta.validate_python(logs)
+            _write_output_file(
+                output_file_path,
+                "\n".join(validated_logs) + ("\n" if validated_logs else ""),
             )
-        )
-        validated_logs = _str_list_ta.validate_python(logs)
-        _write_output_file(
-            output_file_path,
-            "\n".join(validated_logs) + ("\n" if validated_logs else ""),
-        )
-        return TaskLogsWriteResult(num_logs=len(validated_logs))
+            total_logs += len(validated_logs)
+
+        return TaskLogsWriteResult(num_logs=total_logs)
 
     return await _run_tool(
         _run,

--- a/src/ah/src/ah_mcp/server.py
+++ b/src/ah/src/ah_mcp/server.py
@@ -85,7 +85,7 @@ from ah_mcp.models import (
     Thread,
     Version,
     VersionCreation,
-    VersionFromArchiveInput,
+    VersionFromFileInput,
     VersionFromUrlInput,
     VersionNameIndexEntry,
 )
@@ -219,7 +219,7 @@ def _assert_version_creation_enabled() -> None:
         raise RuntimeError(
             "AuditHub version creation is disabled. Restart the server with "
             "--enable-version-creation or AH_ENABLE_VERSION_CREATION=1 to enable "
-            "create_version_from_archive and create_version_from_url."
+            "create_version_from_file and create_version_from_url."
         )
 
 
@@ -1273,10 +1273,10 @@ async def create_version_from_url(
     )
 
 
-async def create_version_from_archive(
+async def create_version_from_file(
     organization_id: _AhId,
     project_id: _AhId,
-    version_input: VersionFromArchiveInput,
+    version_input: VersionFromFileInput,
 ) -> VersionCreation:
     """Create an AuditHub project version by uploading a local .zip archive."""
 
@@ -1296,7 +1296,7 @@ async def create_version_from_archive(
 
     return await _run_tool(
         _run,
-        tool_name=_CREATE_VERSION_FROM_ARCHIVE_TOOL_NAME,
+        tool_name=_CREATE_VERSION_FROM_FILE_TOOL_NAME,
         safe_args={"organization_id": organization_id, "project_id": project_id},
     )
 
@@ -1306,7 +1306,7 @@ async def _create_version_from_archive_with_client(
     *,
     organization_id: int,
     project_id: int,
-    version_input: VersionFromArchiveInput,
+    version_input: VersionFromFileInput,
 ) -> VersionCreation:
     """Create a version by sending the .zip archive as multipart upload data."""
     method, url, headers, body, post_params = client.param_serialize(
@@ -1347,7 +1347,7 @@ async def _create_version_from_archive_with_client(
 
 _RUN_ORCA_TASK_TOOL_NAME = "run_orca_task"
 _RUN_DEFI_VANGUARD_TASK_TOOL_NAME = "run_defi_vanguard_task"
-_CREATE_VERSION_FROM_ARCHIVE_TOOL_NAME = "create_version_from_archive"
+_CREATE_VERSION_FROM_FILE_TOOL_NAME = "create_version_from_file"
 _CREATE_VERSION_FROM_URL_TOOL_NAME = "create_version_from_url"
 
 _TASK_RUN_TOOLS = (
@@ -1355,7 +1355,7 @@ _TASK_RUN_TOOLS = (
     RegisteredTool(_RUN_DEFI_VANGUARD_TASK_TOOL_NAME, run_defi_vanguard_task),
 )
 _VERSION_CREATION_TOOLS = (
-    RegisteredTool(_CREATE_VERSION_FROM_ARCHIVE_TOOL_NAME, create_version_from_archive),
+    RegisteredTool(_CREATE_VERSION_FROM_FILE_TOOL_NAME, create_version_from_file),
     RegisteredTool(_CREATE_VERSION_FROM_URL_TOOL_NAME, create_version_from_url),
 )
 

--- a/src/ah/tests/test_config.py
+++ b/src/ah/tests/test_config.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pydantic import SecretStr
 
 import ah_mcp.config as config
 
@@ -93,7 +94,7 @@ def test_update_config_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
         audithub_base_url="https://before.example/api/v1",
         audithub_oidc_configuration_url="https://before/.well-known/openid-configuration",
         audithub_oidc_client_id="before-client-id",
-        audithub_oidc_client_secret="before-client-secret",
+        audithub_oidc_client_secret=SecretStr("before-client-secret"),
         allowed_org_ids=[1],
         allowed_project_ids=[10],
         enable_task_runs=False,

--- a/src/ah/tests/test_security.py
+++ b/src/ah/tests/test_security.py
@@ -117,8 +117,8 @@ class TestDisallowedIds(unittest.IsolatedAsyncioTestCase):
                 await server.get_task_logs(
                     organization_id=999,
                     task_id=10,
-                    step_code="analysis",
-                    output_file_path=str(output_path),
+                    step_codes=["analysis"],
+                    output_paths=[str(output_path)],
                 )
         self.assertIn("999", str(cm.exception))
         self.assertNotIn("frozenset", str(cm.exception))
@@ -131,8 +131,8 @@ class TestDisallowedIds(unittest.IsolatedAsyncioTestCase):
                 result = await server.get_task_logs(
                     organization_id=1,
                     task_id=10,
-                    step_code="analysis",
-                    output_file_path=str(output_path),
+                    step_codes=["analysis"],
+                    output_paths=[str(output_path)],
                 )
             self.assertEqual(result.num_logs, 2)
             self.assertEqual(output_path.read_text(encoding="utf-8"), "line 1\nline 2\n")
@@ -478,8 +478,8 @@ class TestStepCodePrivacy(unittest.IsolatedAsyncioTestCase):
                 await server.get_task_logs(
                     organization_id=1,
                     task_id=1,
-                    step_code=step_code,
-                    output_file_path=str(output_path),
+                    step_codes=[step_code],
+                    output_paths=[str(output_path)],
                 )
         for call in mock_info.call_args_list:
             args = " ".join(str(arg) for arg in call.args)

--- a/src/ah/tests/test_security.py
+++ b/src/ah/tests/test_security.py
@@ -156,6 +156,25 @@ class TestDisallowedIds(unittest.IsolatedAsyncioTestCase):
             await server.get_task_artifacts(organization_id=999, task_id=10)
         mock.assert_not_awaited()
 
+    async def test_wait_for_task_completion_disallowed_org(self) -> None:
+        with self.assertRaises(RuntimeError) as cm:
+            await server.wait_for_task_completion(organization_id=999, task_id=10)
+        self.assertIn("999", str(cm.exception))
+        self.assertNotIn("frozenset", str(cm.exception))
+
+    async def test_wait_for_task_completion_rejected_call_does_not_reach_sdk(self) -> None:
+        mock = AsyncMock(return_value={"id": 10, "status": "Pending", "steps": []})
+        with (
+            patch.object(
+                server.TasksApi,
+                "get_info_organizations_organization_id_tasks_task_id_get",
+                mock,
+            ),
+            self.assertRaises(RuntimeError),
+        ):
+            await server.wait_for_task_completion(organization_id=999, task_id=10)
+        mock.assert_not_awaited()
+
     async def test_task_artifact_disallowed_org(self) -> None:
         with self.assertRaises(RuntimeError) as cm:
             await server.get_task_artifact(

--- a/src/ah/tests/test_security.py
+++ b/src/ah/tests/test_security.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -78,8 +80,14 @@ class TestDisallowedIds(unittest.IsolatedAsyncioTestCase):
         mock.assert_not_awaited()
 
     async def test_task_findings_disallowed_org(self) -> None:
-        with self.assertRaises(RuntimeError) as cm:
-            await server.get_task_findings(organization_id=999, task_id=10)
+        with TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "findings.json"
+            with self.assertRaises(RuntimeError) as cm:
+                await server.get_task_findings(
+                    organization_id=999,
+                    task_id=10,
+                    output_file_path=str(output_path),
+                )
         self.assertIn("999", str(cm.exception))
         self.assertNotIn("frozenset", str(cm.exception))
 
@@ -92,9 +100,42 @@ class TestDisallowedIds(unittest.IsolatedAsyncioTestCase):
                 mock,
             ),
             self.assertRaises(RuntimeError),
+            TemporaryDirectory() as tmpdir,
         ):
-            await server.get_task_findings(organization_id=999, task_id=10)
+            output_path = Path(tmpdir) / "findings.json"
+            await server.get_task_findings(
+                organization_id=999,
+                task_id=10,
+                output_file_path=str(output_path),
+            )
         mock.assert_not_awaited()
+
+    async def test_task_logs_disallowed_org(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "logs.txt"
+            with self.assertRaises(RuntimeError) as cm:
+                await server.get_task_logs(
+                    organization_id=999,
+                    task_id=10,
+                    step_code="analysis",
+                    output_file_path=str(output_path),
+                )
+        self.assertIn("999", str(cm.exception))
+        self.assertNotIn("frozenset", str(cm.exception))
+
+    async def test_task_logs_writes_to_output_file(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "logs.txt"
+            mock = AsyncMock(return_value=["line 1", "line 2"])
+            with patch.object(server, "_with_api_client", mock):
+                result = await server.get_task_logs(
+                    organization_id=1,
+                    task_id=10,
+                    step_code="analysis",
+                    output_file_path=str(output_path),
+                )
+            self.assertEqual(result.num_logs, 2)
+            self.assertEqual(output_path.read_text(encoding="utf-8"), "line 1\nline 2\n")
 
     async def test_task_artifacts_disallowed_org(self) -> None:
         with self.assertRaises(RuntimeError) as cm:
@@ -424,15 +465,22 @@ class TestStepCodePrivacy(unittest.IsolatedAsyncioTestCase):
         import ah_mcp.audit as audit_mod
 
         step_code = "../../../etc/passwd"
-        with (
-            patch.object(
-                server.TasksApi,
-                "get_output_organizations_organization_id_tasks_task_id_step_code_output_get",
-                AsyncMock(return_value=[]),
-            ),
-            patch.object(audit_mod.logger, "info") as mock_info,
-        ):
-            await server.get_task_logs(organization_id=1, task_id=1, step_code=step_code)
+        with TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "logs.txt"
+            with (
+                patch.object(
+                    server.TasksApi,
+                    "get_output_organizations_organization_id_tasks_task_id_step_code_output_get",
+                    AsyncMock(return_value=[]),
+                ),
+                patch.object(audit_mod.logger, "info") as mock_info,
+            ):
+                await server.get_task_logs(
+                    organization_id=1,
+                    task_id=1,
+                    step_code=step_code,
+                    output_file_path=str(output_path),
+                )
         for call in mock_info.call_args_list:
             args = " ".join(str(arg) for arg in call.args)
             self.assertNotIn(step_code, args)

--- a/src/ah/tests/test_security.py
+++ b/src/ah/tests/test_security.py
@@ -14,7 +14,7 @@ from ah_mcp.models import (  # noqa: E402
     OrCaAdHocSpecReference,
     OrCaParametersInput,
     OrCaTaskInput,
-    VersionFromArchiveInput,
+    VersionFromFileInput,
     VersionFromUrlInput,
 )
 
@@ -343,10 +343,10 @@ class TestDisallowedIds(unittest.IsolatedAsyncioTestCase):
             ),
             self.assertRaises(RuntimeError) as cm,
         ):
-            await server.create_version_from_archive(
+            await server.create_version_from_file(
                 organization_id=999,
                 project_id=10,
-                version_input=VersionFromArchiveInput(
+                version_input=VersionFromFileInput(
                     name="v2.0",
                     archive="ARCHIVE_CONTENTS",
                 ),
@@ -366,10 +366,10 @@ class TestDisallowedIds(unittest.IsolatedAsyncioTestCase):
             ),
             self.assertRaises(RuntimeError) as cm,
         ):
-            await server.create_version_from_archive(
+            await server.create_version_from_file(
                 organization_id=1,
                 project_id=999,
-                version_input=VersionFromArchiveInput(
+                version_input=VersionFromFileInput(
                     name="v2.0",
                     archive="ARCHIVE_CONTENTS",
                 ),
@@ -602,10 +602,10 @@ class TestVersionCreationPrivacy(unittest.IsolatedAsyncioTestCase):
             ),
             patch.object(audit_mod.logger, "info") as mock_info,
         ):
-            await server.create_version_from_archive(
+            await server.create_version_from_file(
                 organization_id=1,
                 project_id=10,
-                version_input=VersionFromArchiveInput(
+                version_input=VersionFromFileInput(
                     name="secret-version",
                     archive=archive,
                 ),

--- a/src/ah/tests/test_server.py
+++ b/src/ah/tests/test_server.py
@@ -740,21 +740,35 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
 
     async def test_get_task_logs_returns_list(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            output_path = Path(tmpdir) / "task-logs.txt"
+            output_path_1 = Path(tmpdir) / "task-logs-1.txt"
+            output_path_2 = Path(tmpdir) / "task-logs-2.txt"
             with patch.object(
                 server.TasksApi,
                 "get_output_organizations_organization_id_tasks_task_id_step_code_output_get",
-                AsyncMock(return_value=["a", "b"]),
+                AsyncMock(side_effect=[["a", "b"], ["c"]]),
             ):
                 result = await server.get_task_logs(
                     organization_id=1,
                     task_id=99,
-                    step_code="analysis",
-                    output_file_path=str(output_path),
+                    step_codes=["analysis", "triage"],
+                    output_paths=[str(output_path_1), str(output_path_2)],
                 )
             self.assertIsInstance(result, server.TaskLogsWriteResult)
-            self.assertEqual(result.num_logs, 2)
-            self.assertEqual(output_path.read_text(encoding="utf-8"), "a\nb\n")
+            self.assertEqual(result.num_logs, 3)
+            self.assertEqual(output_path_1.read_text(encoding="utf-8"), "a\nb\n")
+            self.assertEqual(output_path_2.read_text(encoding="utf-8"), "c\n")
+
+    async def test_get_task_logs_rejects_mismatched_pairs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "task-logs.txt"
+            with self.assertRaises(RuntimeError) as cm:
+                await server.get_task_logs(
+                    organization_id=1,
+                    task_id=99,
+                    step_codes=["analysis", "triage"],
+                    output_paths=[str(output_path)],
+                )
+        self.assertIn("internal error", str(cm.exception).lower())
 
     async def test_get_task_findings_writes_json_and_returns_count(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/src/ah/tests/test_server.py
+++ b/src/ah/tests/test_server.py
@@ -586,7 +586,7 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             server._allowed_org_ids = frozenset({1, 2})
             result = await server.get_organization_name_index()
         self.assertEqual([item.id for item in result], [2, 1])
-        self.assertEqual([item.lookup_key for item in result], ["alpha", "zebra"])
+        self.assertEqual([item.sort_key for item in result], ["alpha", "zebra"])
         self.assertTrue(all(isinstance(item, OrganizationNameIndexEntry) for item in result))
 
     async def test_get_project_returns_project(self) -> None:
@@ -609,7 +609,7 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             server._allowed_project_ids = frozenset({10, 20})
             result = await server.get_project_name_index(organization_id=1)
         self.assertEqual([item.id for item in result], [10, 20])
-        self.assertEqual([item.lookup_key for item in result], ["audit", "zebra"])
+        self.assertEqual([item.sort_key for item in result], ["audit", "zebra"])
         self.assertTrue(all(isinstance(item, ProjectNameIndexEntry) for item in result))
         self.assertEqual(
             [call.kwargs for call in mock.await_args_list],
@@ -651,7 +651,7 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             result = await server.get_version_name_index(organization_id=1, project_id=10)
         self.assertEqual([item.id for item in result], [44, 43, 42])
         self.assertEqual(
-            [item.lookup_key for item in result],
+            [item.sort_key for item in result],
             ["alpha", "release candidate", "v1.0"],
         )
         self.assertTrue(all(isinstance(item, VersionNameIndexEntry) for item in result))
@@ -1416,8 +1416,8 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             await server.get_my_organizations()
         self.assertNotIn("network secret", str(cm.exception))
 
-    def test_normalize_lookup_key(self) -> None:
-        self.assertEqual(server._normalize_lookup_key("  AcMe DAO  "), "acme dao")
+    def test_normalize_sort_key(self) -> None:
+        self.assertEqual(server._normalize_sort_key("  AcMe DAO  "), "acme dao")
 
 
 class TestFastMCPSchemaValidation(unittest.IsolatedAsyncioTestCase):

--- a/src/ah/tests/test_server.py
+++ b/src/ah/tests/test_server.py
@@ -7,6 +7,7 @@ import os
 import sys
 import textwrap
 import unittest
+from datetime import UTC, datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
@@ -15,6 +16,7 @@ from unittest.mock import AsyncMock, patch
 from audithub_sdk.models.custom_detector_from_standard_library import (  # noqa: E402
     CustomDetectorFromStandardLibrary,
 )
+from mcp import types as mcp_types
 from pydantic import ValidationError
 
 import ah_mcp.server as server  # noqa: E402
@@ -42,6 +44,7 @@ from ah_mcp.models import (  # noqa: E402
     VersionFromFileInput,
     VersionFromUrlInput,
     VersionNameIndexEntry,
+    WaitForTaskCompletionResult,
 )
 from tests.sdk_stubs import make_public_configuration, make_vanguard_detector
 
@@ -130,6 +133,48 @@ _ARTIFACT_DICT = {
 _TASK_WITH_ARTIFACTS_DICT = {
     **_TASK_DICT,
     "artifacts": [_ARTIFACT_DICT],
+}
+_TASK_PENDING_DICT = {
+    **_TASK_WITH_ARTIFACTS_DICT,
+    "status": "Running",
+    "steps": [
+        {
+            "code": "analysis",
+            "definition": {
+                "caption": "Analysis",
+                "short_name": "analysis",
+                "is_tool": True,
+            },
+            "status": "Pending",
+            "started_at": None,
+            "finished_at": None,
+            "exit_code": None,
+            "error_message": None,
+            "completed_without_timeout": None,
+            "findings_counters": None,
+        }
+    ],
+}
+_TASK_COMPLETED_DICT = {
+    **_TASK_WITH_ARTIFACTS_DICT,
+    "status": "Finished",
+    "steps": [
+        {
+            "code": "analysis",
+            "definition": {
+                "caption": "Analysis",
+                "short_name": "analysis",
+                "is_tool": True,
+            },
+            "status": "Finished",
+            "started_at": None,
+            "finished_at": None,
+            "exit_code": 0,
+            "error_message": None,
+            "completed_without_timeout": True,
+            "findings_counters": None,
+        }
+    ],
 }
 _TASK_CREATION_DICT = {
     "task_id": 123,
@@ -528,10 +573,12 @@ class TestReadOnlyToolSurface(unittest.TestCase):
         self.assertNotIn("create_version_from_url", names)
         for name in names:
             self.assertTrue(
-                name.startswith("get_") or name == "parse_findings_from_task_log",
+                name.startswith("get_")
+                or name in {"parse_findings_from_task_log", "wait_for_task_completion"},
                 msg=f"unexpected default tool name: {name}",
             )
         self.assertIn("parse_findings_from_task_log", names)
+        self.assertIn("wait_for_task_completion", names)
 
     def test_run_orca_task_registers_only_when_enabled(self) -> None:
         server._set_task_runs_enabled(True)
@@ -682,6 +729,93 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(result.artifacts)
         assert result.artifacts is not None
         self.assertIsNone(result.artifacts[0].presigned_url)
+
+    async def test_wait_for_task_completion_polls_until_no_pending_steps(self) -> None:
+        get_info_mock = AsyncMock(side_effect=[_TASK_PENDING_DICT, _TASK_COMPLETED_DICT])
+        sleep_mock = AsyncMock()
+        with (
+            patch.object(
+                server.TasksApi,
+                "get_info_organizations_organization_id_tasks_task_id_get",
+                get_info_mock,
+            ),
+            patch.object(server.asyncio, "sleep", sleep_mock),
+        ):
+            result = await server.wait_for_task_completion(organization_id=1, task_id=99)
+        self.assertIsInstance(result, WaitForTaskCompletionResult)
+        self.assertTrue(result.is_completed)
+        self.assertIsNotNone(result.task.artifacts)
+        assert result.task.artifacts is not None
+        self.assertIsNone(result.task.artifacts[0].presigned_url)
+        self.assertEqual(get_info_mock.await_count, 2)
+        sleep_mock.assert_awaited_once()
+
+    async def test_wait_for_task_completion_uses_task_mode_without_timeout(self) -> None:
+        task = mcp_types.Task(
+            taskId="task-99",
+            status="working",
+            createdAt=datetime(2026, 3, 26, 12, 0, tzinfo=UTC),
+            lastUpdatedAt=datetime(2026, 3, 26, 12, 0, tzinfo=UTC),
+            ttl=None,
+            pollInterval=None,
+        )
+        create_task_result = mcp_types.CreateTaskResult(
+            task=task,
+        )
+        run_task_mock = AsyncMock(return_value=create_task_result)
+        context = server.Context(
+            request_context=SimpleNamespace(
+                experimental=SimpleNamespace(is_task=True, run_task=run_task_mock)
+            )
+        )
+        result = await server.wait_for_task_completion(
+            organization_id=1,
+            task_id=99,
+            context=context,
+        )
+        self.assertIsInstance(result, mcp_types.CreateTaskResult)
+        self.assertEqual(result.task.taskId, "task-99")
+        run_task_mock.assert_awaited_once()
+
+    async def test_wait_for_task_completion_stops_at_timeout(self) -> None:
+        get_info_mock = AsyncMock(return_value=_TASK_PENDING_DICT)
+        sleep_mock = AsyncMock()
+        with (
+            patch.object(
+                server.TasksApi,
+                "get_info_organizations_organization_id_tasks_task_id_get",
+                get_info_mock,
+            ),
+            patch.object(server.asyncio, "sleep", sleep_mock),
+            patch.object(server.time, "monotonic", side_effect=[0.0, 0.0, 0.01, 0.02, 0.06, 0.07]),
+        ):
+            result = await server.wait_for_task_completion(
+                organization_id=1,
+                task_id=99,
+                timeout=0.06,
+            )
+        self.assertIsInstance(result, WaitForTaskCompletionResult)
+        self.assertFalse(result.is_completed)
+        self.assertEqual(result.task.id, _TASK_PENDING_DICT["id"])
+        self.assertEqual(get_info_mock.await_count, 1)
+        sleep_mock.assert_awaited_once()
+        assert sleep_mock.await_args is not None
+        self.assertAlmostEqual(sleep_mock.await_args.args[0], 0.04)
+
+    async def test_wait_for_task_completion_is_listed_as_task_optional(self) -> None:
+        request = mcp_types.ListToolsRequest.model_construct(method="tools/list", params=None)
+        result = await server.mcp._mcp_server.request_handlers[mcp_types.ListToolsRequest](request)
+        list_tools_result = result.root
+        assert isinstance(list_tools_result, mcp_types.ListToolsResult)
+        tool = next(
+            tool for tool in list_tools_result.tools if tool.name == "wait_for_task_completion"
+        )
+        self.assertIsNotNone(tool.execution)
+        assert tool.execution is not None
+        self.assertEqual(tool.execution.taskSupport, mcp_types.TASK_OPTIONAL)
+        timeout_property = tool.inputSchema["properties"]["timeout"]
+        self.assertIn("Maximum number of seconds to wait", timeout_property["description"])
+        self.assertNotIn("timeout", tool.inputSchema.get("required", []))
 
     async def test_get_task_artifacts_returns_sanitized_metadata(self) -> None:
         with patch.object(

--- a/src/ah/tests/test_server.py
+++ b/src/ah/tests/test_server.py
@@ -22,7 +22,6 @@ import ah_mcp.vanguard as vanguard  # noqa: E402
 from ah_mcp.models import (  # noqa: E402
     Comment,
     DefiVanguardV2TaskInput,
-    FIOData,
     IssueDetails,
     IssueForList,
     MyOrganization,
@@ -740,23 +739,53 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
         self.assertIn("exceeding max_bytes=3", str(cm.exception))
 
     async def test_get_task_logs_returns_list(self) -> None:
-        with patch.object(
-            server.TasksApi,
-            "get_output_organizations_organization_id_tasks_task_id_step_code_output_get",
-            AsyncMock(return_value=["a", "b"]),
-        ):
-            result = await server.get_task_logs(organization_id=1, task_id=99, step_code="analysis")
-        self.assertEqual(result, ["a", "b"])
+        with TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "task-logs.txt"
+            with patch.object(
+                server.TasksApi,
+                "get_output_organizations_organization_id_tasks_task_id_step_code_output_get",
+                AsyncMock(return_value=["a", "b"]),
+            ):
+                result = await server.get_task_logs(
+                    organization_id=1,
+                    task_id=99,
+                    step_code="analysis",
+                    output_file_path=str(output_path),
+                )
+            self.assertIsInstance(result, server.TaskLogsWriteResult)
+            self.assertEqual(result.num_logs, 2)
+            self.assertEqual(output_path.read_text(encoding="utf-8"), "a\nb\n")
 
-    async def test_get_task_findings_returns_list(self) -> None:
-        with patch.object(
-            server.TasksApi,
-            "get_task_findings_organizations_organization_id_tasks_task_id_findings_get",
-            AsyncMock(return_value=[_FINDING_DICT]),
-        ):
-            result = await server.get_task_findings(organization_id=1, task_id=99)
-        self.assertEqual(result[0].analysis_result_id, "analysis-1")
-        self.assertIsInstance(result[0], FIOData)
+    async def test_get_task_findings_writes_json_and_returns_count(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "task-findings.json"
+            with patch.object(
+                server.TasksApi,
+                "get_task_findings_organizations_organization_id_tasks_task_id_findings_get",
+                AsyncMock(return_value=[_FINDING_DICT]),
+            ):
+                result = await server.get_task_findings(
+                    organization_id=1,
+                    task_id=99,
+                    output_file_path=str(output_path),
+                )
+            self.assertIsInstance(result, server.FindingsParseResult)
+            self.assertEqual(result.num_findings, 1)
+            rendered = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                rendered,
+                {
+                    "findings": [
+                        {
+                            "state_digest": 123,
+                            "analysis_result_id": "analysis-1",
+                            "is_filtered": False,
+                            "data": {"title": "Unchecked call return value"},
+                            "actions": [],
+                        }
+                    ]
+                },
+            )
 
     async def test_parse_findings_from_task_log_writes_json_and_returns_summary(self) -> None:
         first_log_contents = textwrap.dedent(

--- a/src/ah/tests/test_server.py
+++ b/src/ah/tests/test_server.py
@@ -37,7 +37,7 @@ from ah_mcp.models import (  # noqa: E402
     Thread,
     Version,
     VersionCreation,
-    VersionFromArchiveInput,
+    VersionFromFileInput,
     VersionFromUrlInput,
     VersionNameIndexEntry,
 )
@@ -318,7 +318,7 @@ class TestCtxCache(unittest.TestCase):
         self.assertFalse(server._version_creation_enabled)
         self.assertFalse(server._is_tool_registered("run_orca_task"))
         self.assertFalse(server._is_tool_registered("run_defi_vanguard_task"))
-        self.assertFalse(server._is_tool_registered("create_version_from_archive"))
+        self.assertFalse(server._is_tool_registered("create_version_from_file"))
         self.assertFalse(server._is_tool_registered("create_version_from_url"))
 
     def test_main_enables_task_runs_from_env(self) -> None:
@@ -350,7 +350,7 @@ class TestCtxCache(unittest.TestCase):
             with patch.dict(os.environ, allow_env, clear=True), patch.object(server.mcp, "run"):
                 server.main()
             self.assertTrue(server._version_creation_enabled)
-            self.assertTrue(server._is_tool_registered("create_version_from_archive"))
+            self.assertTrue(server._is_tool_registered("create_version_from_file"))
             self.assertTrue(server._is_tool_registered("create_version_from_url"))
         finally:
             server._set_version_creation_enabled(False)
@@ -392,7 +392,7 @@ class TestCtxCache(unittest.TestCase):
             ):
                 server.main()
             self.assertTrue(server._version_creation_enabled)
-            self.assertTrue(server._is_tool_registered("create_version_from_archive"))
+            self.assertTrue(server._is_tool_registered("create_version_from_file"))
             self.assertTrue(server._is_tool_registered("create_version_from_url"))
         finally:
             server._set_version_creation_enabled(False)
@@ -444,7 +444,7 @@ class TestCtxCache(unittest.TestCase):
             mock_print.assert_called_once()
             rendered = mock_print.call_args.args[0]
             self.assertIn('"name": "run_defi_vanguard_task"', rendered)
-            self.assertIn('"name": "create_version_from_archive"', rendered)
+            self.assertIn('"name": "create_version_from_file"', rendered)
             self.assertIn('"name": "create_version_from_url"', rendered)
             self.assertIsNone(server._context)
         finally:
@@ -521,7 +521,7 @@ class TestReadOnlyToolSurface(unittest.TestCase):
         self.assertGreater(len(names), 0)
         self.assertNotIn("run_orca_task", names)
         self.assertNotIn("run_defi_vanguard_task", names)
-        self.assertNotIn("create_version_from_archive", names)
+        self.assertNotIn("create_version_from_file", names)
         self.assertNotIn("create_version_from_url", names)
         for name in names:
             self.assertTrue(name.startswith("get_"))
@@ -532,10 +532,10 @@ class TestReadOnlyToolSurface(unittest.TestCase):
         self.assertIn("run_orca_task", names)
         self.assertIn("run_defi_vanguard_task", names)
 
-    def test_create_version_from_archive_registers_only_when_enabled(self) -> None:
+    def test_create_version_from_file_registers_only_when_enabled(self) -> None:
         server._set_version_creation_enabled(True)
         names = list(server.mcp._tool_manager._tools.keys())
-        self.assertIn("create_version_from_archive", names)
+        self.assertIn("create_version_from_file", names)
 
     def test_create_version_from_url_registers_only_when_enabled(self) -> None:
         server._set_version_creation_enabled(True)
@@ -1121,7 +1121,7 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
         self.assertIn("version creation is disabled", str(cm.exception))
         mock.assert_not_awaited()
 
-    async def test_create_version_from_archive_disabled_prevents_sdk_call(self) -> None:
+    async def test_create_version_from_file_disabled_prevents_sdk_call(self) -> None:
         mock = AsyncMock(return_value=_VERSION_CREATION_DICT)
         with (
             patch.object(
@@ -1131,10 +1131,10 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             ),
             self.assertRaises(RuntimeError) as cm,
         ):
-            await server.create_version_from_archive(
+            await server.create_version_from_file(
                 organization_id=1,
                 project_id=10,
-                version_input=VersionFromArchiveInput(
+                version_input=VersionFromFileInput(
                     name="v2.0",
                     archive="ARCHIVE_CONTENTS",
                     commit_hash="def456",
@@ -1143,7 +1143,7 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
         self.assertIn("version creation is disabled", str(cm.exception))
         mock.assert_not_awaited()
 
-    async def test_create_version_from_archive_uses_multipart_upload(self) -> None:
+    async def test_create_version_from_file_uses_multipart_upload(self) -> None:
         server._set_version_creation_enabled(True)
 
         class _FakeResponse:
@@ -1185,7 +1185,7 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             client,
             organization_id=1,
             project_id=10,
-            version_input=VersionFromArchiveInput(
+            version_input=VersionFromFileInput(
                 name="v2.0",
                 archive="/tmp/archive.zip",
                 commit_hash="def456",

--- a/src/ah/tests/test_server.py
+++ b/src/ah/tests/test_server.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 from audithub_sdk.models.custom_detector_from_standard_library import (  # noqa: E402
@@ -763,9 +764,12 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             task=task,
         )
         run_task_mock = AsyncMock(return_value=create_task_result)
-        context = server.Context(
-            request_context=SimpleNamespace(
-                experimental=SimpleNamespace(is_task=True, run_task=run_task_mock)
+        context: server.Context[Any, Any, Any] = server.Context(
+            request_context=cast(
+                Any,
+                SimpleNamespace(
+                    experimental=SimpleNamespace(is_task=True, run_task=run_task_mock)
+                ),
             )
         )
         result = await server.wait_for_task_completion(

--- a/src/ah/tests/test_server.py
+++ b/src/ah/tests/test_server.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
+import textwrap
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -446,6 +449,7 @@ class TestCtxCache(unittest.TestCase):
             self.assertIn('"name": "run_defi_vanguard_task"', rendered)
             self.assertIn('"name": "create_version_from_file"', rendered)
             self.assertIn('"name": "create_version_from_url"', rendered)
+            self.assertIn('"name": "parse_findings_from_task_log"', rendered)
             self.assertIsNone(server._context)
         finally:
             server._set_task_runs_enabled(False)
@@ -524,7 +528,11 @@ class TestReadOnlyToolSurface(unittest.TestCase):
         self.assertNotIn("create_version_from_file", names)
         self.assertNotIn("create_version_from_url", names)
         for name in names:
-            self.assertTrue(name.startswith("get_"))
+            self.assertTrue(
+                name.startswith("get_") or name == "parse_findings_from_task_log",
+                msg=f"unexpected default tool name: {name}",
+            )
+        self.assertIn("parse_findings_from_task_log", names)
 
     def test_run_orca_task_registers_only_when_enabled(self) -> None:
         server._set_task_runs_enabled(True)
@@ -749,6 +757,71 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
             result = await server.get_task_findings(organization_id=1, task_id=99)
         self.assertEqual(result[0].analysis_result_id, "analysis-1")
         self.assertIsInstance(result[0], FIOData)
+
+    async def test_parse_findings_from_task_log_writes_json_and_returns_summary(self) -> None:
+        first_log_contents = textwrap.dedent(
+            """
+            [Medium] First finding
+            Reported By: vanguard:hiyul/unchecked-return
+            Details:
+            First line
+            Second line
+
+            """
+        ).strip()
+        second_log_contents = textwrap.dedent(
+            """
+            [Low] Second finding
+            Reported By: vanguard:stdlib/library-guard
+            Details:
+            Another finding
+            """
+        ).strip()
+        with TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            first_log_path = tmp_path / "task-1.log"
+            second_log_path = tmp_path / "task-2.log"
+            output_path = tmp_path / "findings.json"
+            first_log_path.write_text(first_log_contents, encoding="utf-8")
+            second_log_path.write_text(second_log_contents, encoding="utf-8")
+
+            result = await server.parse_findings_from_task_log(
+                log_file_paths=[str(first_log_path), str(second_log_path)],
+                output_file_path=str(output_path),
+            )
+
+            self.assertIsInstance(result, server.FindingsParseResult)
+            self.assertEqual(result.num_findings, 2)
+            self.assertEqual(
+                result.num_findings_by_log_file_path,
+                {
+                    str(first_log_path): 1,
+                    str(second_log_path): 1,
+                },
+            )
+            rendered = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                rendered,
+                {
+                    "findings": [
+                        {
+                            "title": "First finding",
+                            "detector": "hiyul/unchecked-return",
+                            "description": "First line\nSecond line",
+                        },
+                        {
+                            "title": "Second finding",
+                            "detector": "stdlib/library-guard",
+                            "description": "Another finding",
+                        },
+                    ],
+                    "num_findings": 2,
+                    "num_findings_by_log_file_path": {
+                        str(first_log_path): 1,
+                        str(second_log_path): 1,
+                    },
+                },
+            )
 
     async def test_run_orca_task_disabled_prevents_sdk_call(self) -> None:
         mock = AsyncMock(return_value=_TASK_CREATION_DICT)


### PR DESCRIPTION
This PR extends `ah-mcp` to support a workflow for running tool tasks, fetching the finding results, and triaging them.

* Refactored some tools to take bulk inputs to (1) reduce running time and (2) improve context usage efficiency.
* Added a new `parse_findings_from_task_logs` tool to read findings reported by a task (in the logs) into a JSON object. This is more accurate and faster than the agent doing it manually.
* Added a `wait_for_task_completion` tool that the agent can use to repeatedly poll a task until it is complete.
* Examples of prompts for the workflow have been added to `docs/prompting.md`

Notes:
* The log parsing functionality is essentially a prototype; a proper implementation needs to be based on the FIO SDK.
* I have not tried the triage functionality with OrCa or Picus. It assumes the FIO data is reported in the logs.