### PR TITLE
vanguard: add help_context tool for injecting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ configuration file.
 | `get_project_issues` | Get all issues for a project |
 | `get_project_issue` | Get a specific issue from a project |
 | `get_project_comments` | Get all comments for a project across all versions |
+| `help_context` | Get a prompt/instructions on how agents should use the mcp server |
 | `run_orca_task` | Start an OrCa task for a project version; registered only when task runs are explicitly enabled |
 | `run_defi_vanguard_task` | Start a DeFi Vanguard task for a project version; registered only when task runs are explicitly enabled |
 | `create_version_from_file` | Create a project version by uploading a local `.zip` archive; registered only when version creation is explicitly enabled |
@@ -133,6 +134,12 @@ All tools return typed Python objects backed by `audithub-sdk` models.
 The objects returned by `get_organizations`, `get_projects`, and `get_versions`
 only exposes items belonging to organizations/projects on the configured
 allowlists.
+
+## Available MCP Resources
+
+| Resource | Description |
+|---|---|
+| `docs://vanguard/custom-detectors` | Vanguard custom-detector documentation resource; the server fetches the linked markdown files on first access, caches the rendered text in memory, and returns the markdown bodies |
 
 ## Security Model
 

--- a/docs/vanguard-design.md
+++ b/docs/vanguard-design.md
@@ -17,8 +17,14 @@ documentation:
 
 - `docs://vanguard/custom-detectors`
 
-The resource returns a JSON object with links to documentation pages for
-Vanguard custom detectors.
+The resource returns a JSON object mapping document titles to the markdown text
+of relevant documentation pages.
+
+Behavior:
+
+- The server downloads the markdown texts the first time the resource is read.
+- The downloaded text is cached in memory for the lifetime of the process.
+- If any of the fetches returns a non-OK HTTP response, the resource read fails.
 
 ## Catalog Flow
 

--- a/src/audithub_mcp/server.py
+++ b/src/audithub_mcp/server.py
@@ -16,6 +16,7 @@ import inspect
 import json
 import sys
 import time
+import urllib.request
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -114,15 +115,16 @@ __all__ = [
     "audithub_sdk",
 ]
 
-mcp = FastMCP("audithub_mcp")
+mcp = FastMCP("audithub-mcp")
 mcp._mcp_server.experimental.enable_tasks()
 
 _VANGUARD_CUSTOM_DETECTOR_DOCS_RESOURCE_URI = "docs://vanguard/custom-detectors"
 _VANGUARD_CUSTOM_DETECTOR_DOCS = {
-    "Custom Detector Definition": "https://docs.audithub.dev/vanguard/custom-detectors/",
-    "PAQL Reference": "https://docs.audithub.dev/vanguard/custom-detectors/paql",
-    "Solidity PAQL Dialect": "https://docs.audithub.dev/vanguard/custom-detectors/solidity-dialect",
+    "Custom Detector Definition": "https://docs.audithub.dev/vanguard/custom-detectors/custom-detector-definition.md",
+    "PAQL Reference": "https://docs.audithub.dev/vanguard/custom-detectors/paql.md",
+    "Solidity PAQL Dialect": "https://docs.audithub.dev/vanguard/custom-detectors/solidity-dialect.md",
 }
+_VANGUARD_CUSTOM_DETECTOR_DOCS_CACHE: dict[str, str] | None = None
 
 
 _context: AuditHubSdkContext | None = None
@@ -240,6 +242,12 @@ def _set_edit_custom_detectors_enabled(enabled: bool) -> None:
     global _edit_custom_detectors_enabled
     _edit_custom_detectors_enabled = enabled
     _set_registered_tools_enabled(_CUSTOM_DETECTOR_UPLOAD_TOOLS, enabled)
+
+
+def _reset_vanguard_custom_detector_docs_cache() -> None:
+    """Clear the cached Vanguard custom detector documentation."""
+    global _VANGUARD_CUSTOM_DETECTOR_DOCS_CACHE
+    _VANGUARD_CUSTOM_DETECTOR_DOCS_CACHE = None
 
 
 def _assert_task_runs_enabled() -> None:
@@ -388,12 +396,21 @@ async def _list_tools() -> None:
     _VANGUARD_CUSTOM_DETECTOR_DOCS_RESOURCE_URI,
     name="vanguard_custom_detector_docs",
     title="Vanguard custom detector docs",
-    description="Links to AuditHub's PAQL and Solidity PAQL documentation.",
+    description="Markdown documentation for AuditHub custom detectors",
     mime_type="application/json",
 )
 def get_vanguard_custom_detector_docs() -> dict[str, str]:
-    """Return links to the AuditHub custom-detector documentation."""
-    return _VANGUARD_CUSTOM_DETECTOR_DOCS
+    """Return markdown documentation for AuditHub custom detectors."""
+    global _VANGUARD_CUSTOM_DETECTOR_DOCS_CACHE
+    if _VANGUARD_CUSTOM_DETECTOR_DOCS_CACHE is None:
+        downloaded_docs: dict[str, str] = {}
+        for title, url in _VANGUARD_CUSTOM_DETECTOR_DOCS.items():
+            with urllib.request.urlopen(url) as response:
+                downloaded_docs[title] = response.read().decode(
+                    response.headers.get_content_charset() or "utf-8"
+                )
+        _VANGUARD_CUSTOM_DETECTOR_DOCS_CACHE = downloaded_docs
+    return dict(_VANGUARD_CUSTOM_DETECTOR_DOCS_CACHE)
 
 
 def _ctx() -> AuditHubSdkContext:
@@ -597,6 +614,21 @@ async def get_organizations(
         tool_name="get_organizations",
         safe_args={"filter_id": filter_id},
     )
+
+
+@mcp.tool()
+async def help_context() -> str:
+    """Get resources related to using the audithub-mcp server."""
+
+    return """\
+For authoritative information on Vanguard custom detectors, read the markdown at the audithub-mcp
+resource: docs://vanguard/custom-detectors.
+
+To retrieve the findings of a Vanguard task, use the get_task_logs and parse_findings_from_task_log
+tools.
+Do not use get_task_artifact to download findings.
+Never read any findings.json file directly.
+"""
 
 
 @mcp.tool()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,12 +68,14 @@ def setup_module() -> None:
     server._context = server._build_context()
     server._allowed_org_ids = frozenset({_ORG_ID})
     server._allowed_project_ids = frozenset({_PROJECT_ID})
+    server._reset_vanguard_custom_detector_docs_cache()
 
 
 def teardown_module() -> None:
     server._context = None
     server._allowed_org_ids = frozenset()
     server._allowed_project_ids = frozenset()
+    server._reset_vanguard_custom_detector_docs_cache()
 
 
 def test_list_organizations() -> None:
@@ -120,6 +122,11 @@ def test_get_versions_details() -> None:
     assert all(version.id > 0 for version in versions)
     assert all(isinstance(version.latest, bool) for version in versions)
     assert any(version.latest for version in versions)
+
+
+def test_vanguard_custom_detector_docs_resource() -> None:
+    contents = _run(server.mcp.read_resource(server._VANGUARD_CUSTOM_DETECTOR_DOCS_RESOURCE_URI))
+    assert len(list(contents)) == 1
 
 
 def test_list_vanguard_detectors() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,6 +8,7 @@ import os
 import sys
 import textwrap
 import unittest
+import urllib.error
 from datetime import UTC, datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -19,6 +20,7 @@ from audithub_sdk.models.custom_detector_from_standard_library import (  # noqa:
     CustomDetectorFromStandardLibrary,
 )
 from mcp import types as mcp_types
+from mcp.server.fastmcp.exceptions import ResourceError  # noqa: E402
 from pydantic import ValidationError
 
 import audithub_mcp.server as server  # noqa: E402
@@ -246,6 +248,23 @@ _FULL_ENV: dict[str, str] = {
     "AUDITHUB_OIDC_CLIENT_ID": "test-client-id",
     "AUDITHUB_OIDC_CLIENT_SECRET": "test-client-secret",
 }
+
+
+class _FakeMarkdownResponse:
+    def __init__(self, body: str) -> None:
+        self._body = body.encode("utf-8")
+        self.headers = SimpleNamespace(
+            get_content_charset=lambda default=None: "utf-8",
+        )
+
+    def __enter__(self) -> _FakeMarkdownResponse:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
 
 
 def setUpModule() -> None:
@@ -615,6 +634,7 @@ class TestReadOnlyToolSurface(unittest.TestCase):
     def tearDown(self) -> None:
         server._set_task_runs_enabled(False)
         server._set_version_creation_enabled(False)
+        server._reset_vanguard_custom_detector_docs_cache()
 
     def test_vanguard_custom_detector_docs_resource_is_registered(self) -> None:
         resources = list(asyncio.run(server.mcp.list_resources()))
@@ -627,15 +647,71 @@ class TestReadOnlyToolSurface(unittest.TestCase):
         self.assertEqual(resource.title, "Vanguard custom detector docs")
         self.assertEqual(resource.mimeType, "application/json")
 
-    def test_vanguard_custom_detector_docs_resource_returns_urls(self) -> None:
-        contents = list(
-            asyncio.run(
-                server.mcp.read_resource(server._VANGUARD_CUSTOM_DETECTOR_DOCS_RESOURCE_URI)
+    def test_vanguard_custom_detector_docs_resource_downloads_and_caches_markdown(self) -> None:
+        responses = {
+            server._VANGUARD_CUSTOM_DETECTOR_DOCS[
+                "Custom Detector Definition"
+            ]: _FakeMarkdownResponse("# definition\n"),
+            server._VANGUARD_CUSTOM_DETECTOR_DOCS["PAQL Reference"]: _FakeMarkdownResponse(
+                "# paql\n"
+            ),
+            server._VANGUARD_CUSTOM_DETECTOR_DOCS["Solidity PAQL Dialect"]: _FakeMarkdownResponse(
+                "# solidity\n"
+            ),
+        }
+
+        with patch.object(
+            server.urllib.request,
+            "urlopen",
+            side_effect=lambda url: responses[url],
+        ) as mock_urlopen:
+            contents = list(
+                asyncio.run(
+                    server.mcp.read_resource(server._VANGUARD_CUSTOM_DETECTOR_DOCS_RESOURCE_URI)
+                )
             )
+            self.assertEqual(len(contents), 1)
+            self.assertEqual(contents[0].mime_type, "application/json")
+            self.assertEqual(
+                json.loads(contents[0].content),
+                {
+                    "Custom Detector Definition": "# definition\n",
+                    "PAQL Reference": "# paql\n",
+                    "Solidity PAQL Dialect": "# solidity\n",
+                },
+            )
+
+            cached_contents = list(
+                asyncio.run(
+                    server.mcp.read_resource(server._VANGUARD_CUSTOM_DETECTOR_DOCS_RESOURCE_URI)
+                )
+            )
+            self.assertEqual(len(cached_contents), 1)
+            self.assertEqual(cached_contents[0].content, contents[0].content)
+            self.assertEqual(mock_urlopen.call_count, 3)
+
+    def test_vanguard_custom_detector_docs_resource_raises_on_http_error(self) -> None:
+        error = urllib.error.HTTPError(
+            server._VANGUARD_CUSTOM_DETECTOR_DOCS["PAQL Reference"],
+            404,
+            "Not Found",
+            hdrs=None,
+            fp=None,
         )
-        self.assertEqual(len(contents), 1)
-        self.assertEqual(contents[0].mime_type, "application/json")
-        self.assertEqual(json.loads(contents[0].content), server._VANGUARD_CUSTOM_DETECTOR_DOCS)
+
+        with (
+            patch.object(
+                server.urllib.request,
+                "urlopen",
+                side_effect=(_FakeMarkdownResponse("# definition\n"), error),
+            ),
+            self.assertRaises(ResourceError),
+        ):
+            list(
+                asyncio.run(
+                    server.mcp.read_resource(server._VANGUARD_CUSTOM_DETECTOR_DOCS_RESOURCE_URI)
+                )
+            )
 
     def test_default_tools_start_with_get(self) -> None:
         server._set_task_runs_enabled(False)
@@ -650,7 +726,12 @@ class TestReadOnlyToolSurface(unittest.TestCase):
         for name in names:
             self.assertTrue(
                 name.startswith("get_")
-                or name in {"parse_findings_from_task_log", "wait_for_task_completion"},
+                or name
+                in {
+                    "help_context",
+                    "parse_findings_from_task_log",
+                    "wait_for_task_completion",
+                },
                 msg=f"unexpected default tool name: {name}",
             )
         self.assertIn("parse_findings_from_task_log", names)


### PR DESCRIPTION
For Vanguard, the agent needs context on where the documentation is located and how the tool should be used. To facilitate this, a new help_context tool has been introduced in this commit so that the agent automatically calls the tool to get the required context and instructions.

Additionally, the MCP server name has been changed from audithub_mcp to audithub-mcp to avoid server name problems with resource lookup.