### PR TITLE
Accept custom detector text

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,3 +104,21 @@ appropriate `capabilities` options.
   - `edit_custom_detectors` (boolean)
     - Set to `true` to enable `upload_custom_detector` for organization-level custom
       detectors. Default: `false`.
+    - The tool accepts inline detector source text via `contents`. A local `file_path`
+      remains available for same-machine workflows, but remote MCP clients should pass
+      the detector text directly.
+    - Tool input contract:
+      - Provide either `contents` or `file_path`.
+      - `filename` is required when creating a detector.
+      - `update` selects an existing detector to replace; when updating, `filename` is optional.
+      - If both `contents` and `file_path` are supplied, the inline `contents` value is used.
+      - `file_path` should be an absolute path to a local detector file.
+    - Examples:
+      - Create a detector from inline text:
+        `upload_custom_detector(organization_id=1, contents="...", filename="foo.luau")`
+      - Create a detector from a local file:
+        `upload_custom_detector(organization_id=1, file_path="/abs/path/foo.luau", filename="foo.luau")`
+      - Update detector `42` using inline text:
+        `upload_custom_detector(organization_id=1, contents="...", update=42)`
+      - Update detector `42` and rename it:
+        `upload_custom_detector(organization_id=1, contents="...", filename="bar.luau", update=42)`

--- a/src/audithub_mcp/models.py
+++ b/src/audithub_mcp/models.py
@@ -90,12 +90,27 @@ class CustomDetectorUploadInput(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    file_path: Annotated[str, Field(min_length=1)]
+    contents: Annotated[
+        str | None,
+        Field(
+            min_length=1,
+            description="Inline custom detector source text. Preferred for remote MCP clients.",
+        ),
+    ] = None
+    file_path: Annotated[
+        str | None,
+        Field(
+            min_length=1,
+            description="Absolute path to a local custom detector file for same-machine workflows.",
+        ),
+    ] = None
     filename: Annotated[str | None, Field(min_length=1)] = None
     update: Annotated[_PositiveId | None, Field(description="Custom detector ID to update.")] = None
 
     @model_validator(mode="after")
     def _validate_filename_requirement(self) -> "CustomDetectorUploadInput":
+        if self.contents is None and self.file_path is None:
+            raise ValueError("contents or file_path is required")
         if self.update is None and self.filename is None:
             raise ValueError("filename is required when update is not provided")
         return self

--- a/src/audithub_mcp/server.py
+++ b/src/audithub_mcp/server.py
@@ -644,6 +644,11 @@ async def help_context() -> str:
 For authoritative information on Vanguard custom detectors, read the markdown at the audithub-mcp
 resource: docs://vanguard/custom-detectors.
 
+Custom detector uploads accept either inline `contents` or a local `file_path`. Prefer
+`contents` for remote clients. `filename` is required when creating a detector. `update`
+selects an existing detector; when updating, `filename` is optional. If both `contents` and
+`file_path` are provided, the inline `contents` value is used.
+
 To retrieve the findings of a Vanguard task, use the get_task_logs and parse_findings_from_task_log
 tools.
 Do not use get_task_artifact to download findings.
@@ -1739,6 +1744,18 @@ def _read_custom_detector_contents(file_path: str) -> str:
         raise RuntimeError(f"Failed to read custom detector file {detector_path}: {exc}") from None
 
 
+def _resolve_custom_detector_contents(
+    contents: str | None,
+    file_path: str | None,
+) -> str:
+    """Return custom detector source text from inline contents or a local file."""
+    if contents is not None:
+        return contents
+    if file_path is None:
+        raise RuntimeError("contents or file_path is required")
+    return _read_custom_detector_contents(file_path)
+
+
 async def _get_custom_detector_with_client(
     client: AuthenticatedApiClient,
     *,
@@ -1758,12 +1775,13 @@ async def _upload_custom_detector_with_client(
     client: AuthenticatedApiClient,
     *,
     organization_id: int,
-    file_path: str,
+    contents: str | None,
+    file_path: str | None,
     filename: str | None,
     update: int | None,
 ) -> CustomDetectorUploadResult:
     """Create or update an organization-level custom detector."""
-    contents = _read_custom_detector_contents(file_path)
+    detector_contents = _resolve_custom_detector_contents(contents, file_path)
     if update is None:
         if filename is None:
             raise RuntimeError("filename is required when creating a custom detector")
@@ -1773,7 +1791,7 @@ async def _upload_custom_detector_with_client(
             organization_id=organization_id,
             custom_detector=CustomDetector(
                 filename=filename,
-                contents=contents,
+                contents=detector_contents,
                 encoding="plain",
             ),
         )
@@ -1799,7 +1817,7 @@ async def _upload_custom_detector_with_client(
         custom_detector_id=update,
         custom_detector=CustomDetector(
             filename=resolved_filename,
-            contents=contents,
+            contents=detector_contents,
             encoding="plain",
         ),
     )
@@ -1813,16 +1831,23 @@ async def _upload_custom_detector_with_client(
 @mcp.tool()
 async def upload_custom_detector(
     organization_id: _AhId,
+    contents: Annotated[
+        str | None,
+        Field(
+            min_length=1,
+            description=("Inline custom detector source text. Preferred for remote MCP clients."),
+        ),
+    ] = None,
     file_path: Annotated[
-        str,
+        str | None,
         Field(
             min_length=1,
             description=(
-                "Absolute path to the custom detector definition file. "
+                "Absolute path to a local custom detector file for same-machine workflows. "
                 "MUST follow the format documented in docs://vanguard/custom-detectors"
             ),
         ),
-    ],
+    ] = None,
     filename: Annotated[
         str | None,
         Field(
@@ -1837,7 +1862,7 @@ async def upload_custom_detector(
         Field(description="Custom detector ID to update instead of creating a new detector."),
     ] = None,
 ) -> CustomDetectorUploadResult:
-    """Upload or update an organization-level custom detector from a local file."""
+    """Upload or update an organization-level custom detector."""
 
     async def _run() -> CustomDetectorUploadResult:
         _assert_edit_custom_detectors_enabled()
@@ -1848,6 +1873,7 @@ async def upload_custom_detector(
             lambda client: _upload_custom_detector_with_client(
                 client,
                 organization_id=organization_id,
+                contents=contents,
                 file_path=file_path,
                 filename=filename,
                 update=update,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -358,9 +358,23 @@ class TestBuildContext(unittest.TestCase):
             )
         self.assertIn(".deployment.json", str(cm.exception))
 
+    def test_custom_detector_upload_requires_source(self) -> None:
+        with self.assertRaises(ValidationError) as cm:
+            CustomDetectorUploadInput(filename="detector.luau")
+        self.assertIn("contents or file_path is required", str(cm.exception))
+
+    def test_custom_detector_upload_accepts_inline_contents(self) -> None:
+        input_data = CustomDetectorUploadInput(
+            contents="rule body\n",
+            filename="detector.luau",
+        )
+        self.assertEqual(input_data.contents, "rule body\n")
+        self.assertIsNone(input_data.file_path)
+        self.assertEqual(input_data.filename, "detector.luau")
+
     def test_custom_detector_upload_requires_filename_without_update(self) -> None:
         with self.assertRaises(ValidationError) as cm:
-            CustomDetectorUploadInput(file_path="/tmp/detector.luau")
+            CustomDetectorUploadInput(contents="rule body\n")
         self.assertIn("filename is required", str(cm.exception))
 
     def test_secret_not_in_error_message(self) -> None:
@@ -739,6 +753,16 @@ class TestReadOnlyToolSurface(unittest.TestCase):
         self.assertIn("parse_findings_from_task_log", names)
         self.assertIn("validate_paql", names)
         self.assertIn("wait_for_task_completion", names)
+
+    def test_help_context_mentions_custom_detector_input_contract(self) -> None:
+        help_text = asyncio.run(server.help_context())
+        self.assertIn(
+            "Custom detector uploads accept either inline `contents` or a local `file_path`.",
+            help_text,
+        )
+        self.assertIn("`filename` is required when creating a detector.", help_text)
+        self.assertIn("If both `contents` and", help_text)
+        self.assertIn("`file_path` are provided, the inline `contents` value is used.", help_text)
 
     def test_run_orca_task_registers_only_when_enabled(self) -> None:
         server._set_task_runs_enabled(True)
@@ -1758,6 +1782,32 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
 
     async def test_upload_custom_detector_creates_detector(self) -> None:
         server._set_edit_custom_detectors_enabled(True)
+        mock = AsyncMock(return_value=SimpleNamespace(id=77, message="Detector created"))
+        with patch.object(
+            server.CustomDetectorsOrgLibApi,
+            "post_custom_detector_organizations_organization_id_custom_detectors_post",
+            mock,
+        ):
+            result = await server.upload_custom_detector(
+                organization_id=1,
+                contents="rule body\n",
+                filename="detector.luau",
+            )
+        self.assertIsInstance(result, CustomDetectorUploadResult)
+        self.assertEqual(result.id, 77)
+        self.assertEqual(result.filename, "detector.luau")
+        self.assertEqual(result.message, "Detector created")
+        call_args = mock.await_args
+        assert call_args is not None
+        kwargs = call_args.kwargs
+        self.assertEqual(kwargs["organization_id"], 1)
+        custom_detector = kwargs["custom_detector"]
+        self.assertEqual(custom_detector.filename, "detector.luau")
+        self.assertEqual(custom_detector.contents, "rule body\n")
+        self.assertEqual(custom_detector.encoding, "plain")
+
+    async def test_upload_custom_detector_creates_detector_from_file_path(self) -> None:
+        server._set_edit_custom_detectors_enabled(True)
         with TemporaryDirectory() as tmpdir:
             detector_path = Path(tmpdir) / "detector.luau"
             detector_path.write_text("rule body\n", encoding="utf-8")
@@ -1786,6 +1836,47 @@ class TestToolCalls(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(custom_detector.encoding, "plain")
 
     async def test_upload_custom_detector_updates_detector_using_existing_filename(self) -> None:
+        server._set_edit_custom_detectors_enabled(True)
+        get_mock = AsyncMock(return_value=SimpleNamespace(id=88, filename="existing.luau"))
+        put_mock = AsyncMock(return_value=SimpleNamespace(success=True, message="Detector updated"))
+        with (
+            patch.object(
+                server.CustomDetectorsOrgLibApi,
+                "get_custom_detector_organizations_organization_id_custom_detectors_custom_detector_id_get",
+                get_mock,
+            ),
+            patch.object(
+                server.CustomDetectorsOrgLibApi,
+                "put_custom_detector_organizations_organization_id_custom_detectors_custom_detector_id_put",
+                put_mock,
+            ),
+        ):
+            result = await server.upload_custom_detector(
+                organization_id=1,
+                contents="updated body\n",
+                update=88,
+            )
+        self.assertIsInstance(result, CustomDetectorUploadResult)
+        self.assertEqual(result.id, 88)
+        self.assertEqual(result.filename, "existing.luau")
+        self.assertEqual(result.message, "Detector updated")
+        self.assertIsNotNone(get_mock.await_args)
+        get_call = get_mock.await_args
+        assert get_call is not None
+        get_kwargs = get_call.kwargs
+        self.assertEqual(get_kwargs["organization_id"], 1)
+        self.assertEqual(get_kwargs["custom_detector_id"], 88)
+        self.assertIsNotNone(put_mock.await_args)
+        put_call = put_mock.await_args
+        assert put_call is not None
+        put_kwargs = put_call.kwargs
+        self.assertEqual(put_kwargs["organization_id"], 1)
+        self.assertEqual(put_kwargs["custom_detector_id"], 88)
+        custom_detector = put_kwargs["custom_detector"]
+        self.assertEqual(custom_detector.filename, "existing.luau")
+        self.assertEqual(custom_detector.contents, "updated body\n")
+
+    async def test_upload_custom_detector_updates_detector_from_file_path(self) -> None:
         server._set_edit_custom_detectors_enabled(True)
         with TemporaryDirectory() as tmpdir:
             detector_path = Path(tmpdir) / "detector.luau"


### PR DESCRIPTION
# Issue
 The upload custom detector tool only accepted a file path. This imposes an assumption that the ah and the agent are running in the same environment. This assumption is too strong for MCP running in server mode and in isolation. 

# Fix
The upload custom detector tool now accepts the text of custom detector and file name. Backwards compatibility is maintained by still accepting a path but the text is preferred 